### PR TITLE
Enable deep linking in the now deployment

### DIFF
--- a/now.json
+++ b/now.json
@@ -8,5 +8,10 @@
       "use": "@now/static-build",
       "config": { "distDir": ".docz/dist" }
     }
-  ]
+  ],
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/" }
+  ],
+  "alias": ["design-system.hoppin.now.sh", "design-system-brunobernardino.hoppin.now.sh", "design-system-slowworks.hoppin.now.sh"]
 }


### PR DESCRIPTION
Also auto-alias.

This is already live and can be tested by going to https://design-system.hoppin.now.sh/components/Box, for example.