### PR TITLE
harmonise context/mode, fix Button and Heading colors

### DIFF
--- a/es/components/Button/Button.js
+++ b/es/components/Button/Button.js
@@ -48,14 +48,14 @@ var Button = styled.button(_templateObject, function (_ref) {
   var variantCSS = '';
   switch (variant) {
     case 'outline':
-      variantCSS = '\n          border-color: ' + colors.base + ';\n          color: ' + colors.base + ';\n        ';
+      variantCSS = '\n          border-color: ' + colors.base + ';\n          background-color: transparent;\n          color: ' + colors.base + ';\n        ';
       break;
     case 'subtle':
-      variantCSS = '\n          border-color: \'transparent\';\n          color: ' + colors.base + ';\n\n          &:hover {\n            box-shadow: none;\n          }\n        ';
+      variantCSS = '\n          border-color: transparent;\n          background-color: transparent;\n          color: ' + colors.base + ';\n\n          &:hover {\n            box-shadow: none;\n          }\n        ';
       break;
     case 'full':
     default:
-      variantCSS = '\n          border-color: ' + colors.base + ';\n          background-color: ' + colors.base + ';\n          color: ' + theme.colors.white + ';\n        ';
+      variantCSS = '\n          border-color: ' + colors.base + ';\n          background-color: ' + colors.base + ';\n          color: ' + (context === 'whiteout' ? theme.colors.primary.base : theme.colors.white) + ';\n        ';
       break;
   }
   return variantCSS;
@@ -69,7 +69,7 @@ Button.propTypes = _extends({
 }, systemPropTypes.buttonStyle, systemPropTypes.display, systemPropTypes.space, systemPropTypes.width, systemPropTypes.flex, systemPropTypes.flexGrow, systemPropTypes.flexShrink, systemPropTypes.flexBasis, systemPropTypes.justifySelf, systemPropTypes.alignSelf, systemPropTypes.order, {
   size: propTypes.oneOf(['small', 'base', 'large']),
   variant: propTypes.oneOf(['full', 'outline', 'subtle']),
-  context: propTypes.oneOf(['primary', 'secondary', 'tertiary', 'hopper', 'host', 'danger'])
+  context: propTypes.oneOf(['primary', 'secondary', 'tertiary', 'hopper', 'host', 'danger', 'whiteout'])
 });
 
 Button.defaultProps = {

--- a/es/components/Heading/Heading.js
+++ b/es/components/Heading/Heading.js
@@ -1,6 +1,6 @@
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _templateObject = _taggedTemplateLiteralLoose(['\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n\n  &:first-child {\n    margin-top: 0;\n  }\n\n'], ['\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n\n  &:first-child {\n    margin-top: 0;\n  }\n\n']);
+var _templateObject = _taggedTemplateLiteralLoose(['\n  /* use styled-system variants defined in tokens/typography */\n  ', '\n  /* get color from theme to get dymanic mode colors (host vs hopper)*/\n  ', '\n  /* allow color override with props */\n  ', '\n  /* other styled-system props */\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n\n  &:first-child {\n    margin-top: 0;\n  }\n\n'], ['\n  /* use styled-system variants defined in tokens/typography */\n  ', '\n  /* get color from theme to get dymanic mode colors (host vs hopper)*/\n  ', '\n  /* allow color override with props */\n  ', '\n  /* other styled-system props */\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n\n  &:first-child {\n    margin-top: 0;\n  }\n\n']);
 
 function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
 
@@ -20,7 +20,33 @@ var headingStyles = variant({
   prop: 'as'
 });
 
-var Heading = styled('h2')(_templateObject, headingStyles, space, color, flex, flexGrow, flexShrink, flexBasis, justifySelf, alignSelf, order);
+var Heading = styled('h2')(_templateObject, headingStyles, function (_ref) {
+  var theme = _ref.theme,
+      as = _ref.as;
+
+  var colorCSS = '';
+  switch (as) {
+    case 'h1':
+      colorCSS = 'color: ' + theme.colors.primary.base + ';';
+      break;
+    case 'h2':
+      colorCSS = 'color: ' + theme.colors.primary.darker + ';';
+      break;
+    case 'h3':
+      colorCSS = 'color: ' + theme.colors.neutrals.darker + ';';
+      break;
+    case 'h4':
+      colorCSS = 'color: ' + theme.colors.neutrals.darker + ';';
+      break;
+    case 'h5':
+      colorCSS = 'color: ' + theme.colors.neutrals.dark + ';';
+      break;
+    case 'h6':
+      colorCSS = 'color: ' + theme.colors.neutrals.dark + ';';
+      break;
+  }
+  return colorCSS;
+}, color, space, flex, flexGrow, flexShrink, flexBasis, justifySelf, alignSelf, order);
 
 Heading.propTypes = _extends({}, propTypes.space, propTypes.color, propTypes.flex, propTypes.flexGrow, propTypes.flexShrink, propTypes.flexBasis, propTypes.justifySelf, propTypes.alignSelf, propTypes.order);
 

--- a/es/components/HoppinDesignProvider/HoppinDesignProvider.js
+++ b/es/components/HoppinDesignProvider/HoppinDesignProvider.js
@@ -2,8 +2,8 @@ var _templateObject = _taggedTemplateLiteralLoose(['\n  html,\n  body,\n  * {\n 
 
 function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
 
-import React from 'react';
-import { ThemeProvider } from 'styled-components';
+import React, { useContext } from 'react';
+import { ThemeProvider, ThemeContext } from 'styled-components';
 import tokens from '../../tokens';
 import propTypes from 'prop-types';
 import { createGlobalStyle } from 'styled-components';
@@ -16,19 +16,24 @@ var GlobalStyle = createGlobalStyle(_templateObject, tokens.fonts.secondary, fun
 
 var HoppinDesignProvider = function HoppinDesignProvider(_ref2) {
   var children = _ref2.children,
-      mode = _ref2.mode,
+      context = _ref2.context,
       theme = _ref2.theme;
 
-  console.log(theme, tokens);
+  // Get theme from the react context.
+  // This is used when we use nested HoppinDesignProviders,
+  // it will inherit the tokens/theme form it's parent, no need to pass in a new theme, just set the context.
+  var themeContext = useContext(ThemeContext);
   // if we specify a theme-override, merge it with the default tokens
-  var tokensWithOverrides = merge({}, tokens, theme);
+  var tokensWithOverrides = merge({}, tokens, themeContext, theme);
   // depending on mode, set the primary colors
-  var tokensWithMode = merge({}, tokens, {
-    colors: get(tokensWithOverrides.colors.modes, mode, tokensWithOverrides.colors)
+  var tokensWithContext = merge({}, tokensWithOverrides, {
+    colors: get(tokensWithOverrides.colors.contexts, context, tokensWithOverrides.colors)
   });
+
+  console.log('merged tokensWithContext', tokensWithContext);
   return React.createElement(
     ThemeProvider,
-    { theme: tokensWithMode },
+    { theme: tokensWithContext },
     React.createElement(
       React.Fragment,
       null,

--- a/es/tokens/colors.js
+++ b/es/tokens/colors.js
@@ -48,15 +48,25 @@ var colors = {
     dark: '#47647e',
     darker: '#243b53',
     darkest: '#112233'
+  },
+
+  whiteout: {
+    lightest: '#fff',
+    lighter: '#fff',
+    light: '#fff',
+    base: '#fff',
+    dark: '#fff',
+    darker: '#fff',
+    darkest: '#fff'
   }
 };
 
 // set default "primary" to hopper colors:
 colors.primary = colors.hopper;
 
-// define color modes (like dark and light, in our case hopper and host modes)
-// https://styled-system.com/guides/color-modes
-colors.modes = {
+// define color contexts (like dark and light, in our case hopper and host contexts)
+// https://styled-system.com/guides/color-modes (they call it modes, we call it context to keep it consistent with components-level overrrides (see Button))
+colors.contexts = {
   host: {
     primary: colors.host
   },

--- a/es/tokens/index.js
+++ b/es/tokens/index.js
@@ -4,13 +4,6 @@ import { buttonSizes } from './buttons';
 import { shadows } from './shadows';
 import { fonts, fontSizes, lineHeights, fontWeights, headings } from './typography';
 
-/* exports theme object.
-   make sure to set mode='host' or mod='hopper' in the HoppinDesignProvider to select primary colors.
-   - 'host'   => primary is host pink
-   - 'hopper' => primary is hopper blue
-
-*/
-
 export default {
   space: space,
   containerWidths: containerWidths,

--- a/es/tokens/typography.js
+++ b/es/tokens/typography.js
@@ -40,11 +40,11 @@ var fontWeights = {
   bold: 600
 };
 
+// headings style attributes, all but color, since color is dependent on host/hopper context
 var headings = {
   h1: {
     fontFamily: fonts.primary,
     fontSize: fontSizes.h1,
-    color: colors.primary.base,
     letterSpacing: '-2px',
     lineHeight: lineHeights.base,
     fontWeight: fontWeights.bold,
@@ -54,32 +54,27 @@ var headings = {
   h2: {
     fontFamily: fonts.primary,
     fontSize: fontSizes.h2,
-    color: colors.primary.darker,
     letterSpacing: '-1px',
     fontWeight: fontWeights.bold
   },
   h3: {
     fontFamily: fonts.primary,
     fontSize: fontSizes.h3,
-    color: colors.neutrals.darker,
     fontWeight: fontWeights.bold
   },
   h4: {
     fontFamily: fonts.secondary,
     fontSize: fontSizes.h4,
-    color: colors.neutrals.darker,
     fontWeight: fontWeights.normal
   },
   h5: {
     fontFamily: fonts.secondary,
     fontSize: fontSizes.h5,
-    color: colors.neutrals.dark,
     fontWeight: fontWeights.bold
   },
   h6: {
     fontFamily: fonts.secondary,
     fontSize: fontSizes.h6,
-    color: colors.neutrals.dark,
     textTransform: 'uppercase',
     fontWeight: fontWeights.bold
   }

--- a/lib/components/Button/Button.js
+++ b/lib/components/Button/Button.js
@@ -61,14 +61,14 @@ var Button = _styledComponents2.default.button(_templateObject, function (_ref) 
   var variantCSS = '';
   switch (variant) {
     case 'outline':
-      variantCSS = '\n          border-color: ' + colors.base + ';\n          color: ' + colors.base + ';\n        ';
+      variantCSS = '\n          border-color: ' + colors.base + ';\n          background-color: transparent;\n          color: ' + colors.base + ';\n        ';
       break;
     case 'subtle':
-      variantCSS = '\n          border-color: \'transparent\';\n          color: ' + colors.base + ';\n\n          &:hover {\n            box-shadow: none;\n          }\n        ';
+      variantCSS = '\n          border-color: transparent;\n          background-color: transparent;\n          color: ' + colors.base + ';\n\n          &:hover {\n            box-shadow: none;\n          }\n        ';
       break;
     case 'full':
     default:
-      variantCSS = '\n          border-color: ' + colors.base + ';\n          background-color: ' + colors.base + ';\n          color: ' + theme.colors.white + ';\n        ';
+      variantCSS = '\n          border-color: ' + colors.base + ';\n          background-color: ' + colors.base + ';\n          color: ' + (context === 'whiteout' ? theme.colors.primary.base : theme.colors.white) + ';\n        ';
       break;
   }
   return variantCSS;
@@ -82,7 +82,7 @@ Button.propTypes = _extends({
 }, _propTypes4.default.buttonStyle, _propTypes4.default.display, _propTypes4.default.space, _propTypes4.default.width, _propTypes4.default.flex, _propTypes4.default.flexGrow, _propTypes4.default.flexShrink, _propTypes4.default.flexBasis, _propTypes4.default.justifySelf, _propTypes4.default.alignSelf, _propTypes4.default.order, {
   size: _propTypes2.default.oneOf(['small', 'base', 'large']),
   variant: _propTypes2.default.oneOf(['full', 'outline', 'subtle']),
-  context: _propTypes2.default.oneOf(['primary', 'secondary', 'tertiary', 'hopper', 'host', 'danger'])
+  context: _propTypes2.default.oneOf(['primary', 'secondary', 'tertiary', 'hopper', 'host', 'danger', 'whiteout'])
 });
 
 Button.defaultProps = {

--- a/lib/components/Heading/Heading.js
+++ b/lib/components/Heading/Heading.js
@@ -4,7 +4,7 @@ exports.__esModule = true;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _templateObject = _taggedTemplateLiteralLoose(['\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n\n  &:first-child {\n    margin-top: 0;\n  }\n\n'], ['\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n\n  &:first-child {\n    margin-top: 0;\n  }\n\n']);
+var _templateObject = _taggedTemplateLiteralLoose(['\n  /* use styled-system variants defined in tokens/typography */\n  ', '\n  /* get color from theme to get dymanic mode colors (host vs hopper)*/\n  ', '\n  /* allow color override with props */\n  ', '\n  /* other styled-system props */\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n\n  &:first-child {\n    margin-top: 0;\n  }\n\n'], ['\n  /* use styled-system variants defined in tokens/typography */\n  ', '\n  /* get color from theme to get dymanic mode colors (host vs hopper)*/\n  ', '\n  /* allow color override with props */\n  ', '\n  /* other styled-system props */\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n  ', '\n\n  &:first-child {\n    margin-top: 0;\n  }\n\n']);
 
 var _react = require('react');
 
@@ -35,7 +35,33 @@ var headingStyles = (0, _styledSystem.variant)({
   prop: 'as'
 });
 
-var Heading = (0, _styledComponents2.default)('h2')(_templateObject, headingStyles, _styledSystem.space, _styledSystem.color, _styledSystem.flex, _styledSystem.flexGrow, _styledSystem.flexShrink, _styledSystem.flexBasis, _styledSystem.justifySelf, _styledSystem.alignSelf, _styledSystem.order);
+var Heading = (0, _styledComponents2.default)('h2')(_templateObject, headingStyles, function (_ref) {
+  var theme = _ref.theme,
+      as = _ref.as;
+
+  var colorCSS = '';
+  switch (as) {
+    case 'h1':
+      colorCSS = 'color: ' + theme.colors.primary.base + ';';
+      break;
+    case 'h2':
+      colorCSS = 'color: ' + theme.colors.primary.darker + ';';
+      break;
+    case 'h3':
+      colorCSS = 'color: ' + theme.colors.neutrals.darker + ';';
+      break;
+    case 'h4':
+      colorCSS = 'color: ' + theme.colors.neutrals.darker + ';';
+      break;
+    case 'h5':
+      colorCSS = 'color: ' + theme.colors.neutrals.dark + ';';
+      break;
+    case 'h6':
+      colorCSS = 'color: ' + theme.colors.neutrals.dark + ';';
+      break;
+  }
+  return colorCSS;
+}, _styledSystem.color, _styledSystem.space, _styledSystem.flex, _styledSystem.flexGrow, _styledSystem.flexShrink, _styledSystem.flexBasis, _styledSystem.justifySelf, _styledSystem.alignSelf, _styledSystem.order);
 
 Heading.propTypes = _extends({}, _propTypes2.default.space, _propTypes2.default.color, _propTypes2.default.flex, _propTypes2.default.flexGrow, _propTypes2.default.flexShrink, _propTypes2.default.flexBasis, _propTypes2.default.justifySelf, _propTypes2.default.alignSelf, _propTypes2.default.order);
 

--- a/lib/components/HoppinDesignProvider/HoppinDesignProvider.js
+++ b/lib/components/HoppinDesignProvider/HoppinDesignProvider.js
@@ -31,19 +31,24 @@ var GlobalStyle = (0, _styledComponents.createGlobalStyle)(_templateObject, _tok
 
 var HoppinDesignProvider = function HoppinDesignProvider(_ref2) {
   var children = _ref2.children,
-      mode = _ref2.mode,
+      context = _ref2.context,
       theme = _ref2.theme;
 
-  console.log(theme, _tokens2.default);
+  // Get theme from the react context.
+  // This is used when we use nested HoppinDesignProviders,
+  // it will inherit the tokens/theme form it's parent, no need to pass in a new theme, just set the context.
+  var themeContext = (0, _react.useContext)(_styledComponents.ThemeContext);
   // if we specify a theme-override, merge it with the default tokens
-  var tokensWithOverrides = (0, _lodash.merge)({}, _tokens2.default, theme);
+  var tokensWithOverrides = (0, _lodash.merge)({}, _tokens2.default, themeContext, theme);
   // depending on mode, set the primary colors
-  var tokensWithMode = (0, _lodash.merge)({}, _tokens2.default, {
-    colors: (0, _lodash.get)(tokensWithOverrides.colors.modes, mode, tokensWithOverrides.colors)
+  var tokensWithContext = (0, _lodash.merge)({}, tokensWithOverrides, {
+    colors: (0, _lodash.get)(tokensWithOverrides.colors.contexts, context, tokensWithOverrides.colors)
   });
+
+  console.log('merged tokensWithContext', tokensWithContext);
   return _react2.default.createElement(
     _styledComponents.ThemeProvider,
-    { theme: tokensWithMode },
+    { theme: tokensWithContext },
     _react2.default.createElement(
       _react2.default.Fragment,
       null,

--- a/lib/tokens/colors.js
+++ b/lib/tokens/colors.js
@@ -51,15 +51,25 @@ var colors = {
     dark: '#47647e',
     darker: '#243b53',
     darkest: '#112233'
+  },
+
+  whiteout: {
+    lightest: '#fff',
+    lighter: '#fff',
+    light: '#fff',
+    base: '#fff',
+    dark: '#fff',
+    darker: '#fff',
+    darkest: '#fff'
   }
 };
 
 // set default "primary" to hopper colors:
 colors.primary = colors.hopper;
 
-// define color modes (like dark and light, in our case hopper and host modes)
-// https://styled-system.com/guides/color-modes
-colors.modes = {
+// define color contexts (like dark and light, in our case hopper and host contexts)
+// https://styled-system.com/guides/color-modes (they call it modes, we call it context to keep it consistent with components-level overrrides (see Button))
+colors.contexts = {
   host: {
     primary: colors.host
   },

--- a/lib/tokens/index.js
+++ b/lib/tokens/index.js
@@ -12,13 +12,6 @@ var _shadows = require('./shadows');
 
 var _typography = require('./typography');
 
-/* exports theme object.
-   make sure to set mode='host' or mod='hopper' in the HoppinDesignProvider to select primary colors.
-   - 'host'   => primary is host pink
-   - 'hopper' => primary is hopper blue
-
-*/
-
 exports.default = {
   space: _space.space,
   containerWidths: _space.containerWidths,

--- a/lib/tokens/typography.js
+++ b/lib/tokens/typography.js
@@ -46,11 +46,11 @@ var fontWeights = {
   bold: 600
 };
 
+// headings style attributes, all but color, since color is dependent on host/hopper context
 var headings = {
   h1: {
     fontFamily: fonts.primary,
     fontSize: fontSizes.h1,
-    color: _colors.colors.primary.base,
     letterSpacing: '-2px',
     lineHeight: lineHeights.base,
     fontWeight: fontWeights.bold,
@@ -60,32 +60,27 @@ var headings = {
   h2: {
     fontFamily: fonts.primary,
     fontSize: fontSizes.h2,
-    color: _colors.colors.primary.darker,
     letterSpacing: '-1px',
     fontWeight: fontWeights.bold
   },
   h3: {
     fontFamily: fonts.primary,
     fontSize: fontSizes.h3,
-    color: _colors.colors.neutrals.darker,
     fontWeight: fontWeights.bold
   },
   h4: {
     fontFamily: fonts.secondary,
     fontSize: fontSizes.h4,
-    color: _colors.colors.neutrals.darker,
     fontWeight: fontWeights.normal
   },
   h5: {
     fontFamily: fonts.secondary,
     fontSize: fontSizes.h5,
-    color: _colors.colors.neutrals.dark,
     fontWeight: fontWeights.bold
   },
   h6: {
     fontFamily: fonts.secondary,
     fontSize: fontSizes.h6,
-    color: _colors.colors.neutrals.dark,
     textTransform: 'uppercase',
     fontWeight: fontWeights.bold
   }

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -69,12 +69,14 @@ const Button = styled.button`
       case 'outline':
         variantCSS = `
           border-color: ${colors.base};
+          background-color: transparent;
           color: ${colors.base};
         `;
         break;
       case 'subtle':
         variantCSS = `
-          border-color: 'transparent';
+          border-color: transparent;
+          background-color: transparent;
           color: ${colors.base};
 
           &:hover {
@@ -87,7 +89,11 @@ const Button = styled.button`
         variantCSS = `
           border-color: ${colors.base};
           background-color: ${colors.base};
-          color: ${theme.colors.white};
+          color: ${
+            context === 'whiteout'
+              ? theme.colors.primary.base
+              : theme.colors.white
+          };
         `;
         break;
     }
@@ -141,6 +147,7 @@ Button.propTypes = {
     'hopper',
     'host',
     'danger',
+    'whiteout',
   ]),
 };
 

--- a/src/components/Button/Readme.mdx
+++ b/src/components/Button/Readme.mdx
@@ -6,6 +6,7 @@ menu: Components
 
 import { Props, Playground } from 'docz';
 import { Flex } from '../Flex';
+import { Box } from '../Box';
 import Button from './Button';
 
 # Button
@@ -26,6 +27,9 @@ This is your standard button. They typically trigger one action when interacted 
     <Button context="host">Host</Button>
     <Button context="danger">Danger</Button>
   </Flex>
+  <Box bg="primary.base" padding="large" marginTop="large">
+    <Button context="whiteout">Whiteout</Button>
+  </Box>
 </Playground>
 
 ## Outline Button
@@ -39,8 +43,10 @@ These are our outline buttons. Use them for secondary actions. Most of the time,
 <Button variant='outline' context="hopper">Hopper</Button>
 <Button variant='outline' context="host">Host</Button>
 <Button variant='outline' context="danger">Danger</Button>
-
 </Flex>
+<Box bg="primary.base" padding="large" marginTop="large">
+  <Button variant="outline" context="whiteout">Whiteout</Button>
+</Box>
 </Playground>
 
 ## Subtle Button
@@ -56,6 +62,10 @@ These are our subtle buttons. Use them for when the action is not overly importa
 <Button variant='subtle' context="danger">Danger</Button>
 
 </Flex>
+
+<Box bg="primary.base" padding="large" marginTop="large">
+  <Button variant="subtle" context="whiteout">Whiteout</Button>
+</Box>
 </Playground>
 
 ## Sizes

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -26,9 +26,37 @@ const headingStyles = variant({
 });
 
 const Heading = styled('h2')`
+  /* use styled-system variants defined in tokens/typography */
   ${headingStyles}
-  ${space}
+  /* get color from theme to get dymanic mode colors (host vs hopper)*/
+  ${({ theme, as }) => {
+    let colorCSS = '';
+    switch (as) {
+      case 'h1':
+        colorCSS = `color: ${theme.colors.primary.base};`;
+        break;
+      case 'h2':
+        colorCSS = `color: ${theme.colors.primary.darker};`;
+        break;
+      case 'h3':
+        colorCSS = `color: ${theme.colors.neutrals.darker};`;
+        break;
+      case 'h4':
+        colorCSS = `color: ${theme.colors.neutrals.darker};`;
+        break;
+      case 'h5':
+        colorCSS = `color: ${theme.colors.neutrals.dark};`;
+        break;
+      case 'h6':
+        colorCSS = `color: ${theme.colors.neutrals.dark};`;
+        break;
+    }
+    return colorCSS;
+  }}
+  /* allow color override with props */
   ${color}
+  /* other styled-system props */
+  ${space}
   ${flex}
   ${flexGrow}
   ${flexShrink}

--- a/src/components/HoppinDesignProvider/HoppinDesignProvider.js
+++ b/src/components/HoppinDesignProvider/HoppinDesignProvider.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import { ThemeProvider } from 'styled-components';
+import React, { useContext } from 'react';
+import { ThemeProvider, ThemeContext } from 'styled-components';
 import tokens from '../../tokens';
 import propTypes from 'prop-types';
 import { createGlobalStyle } from 'styled-components';
@@ -45,20 +45,25 @@ const GlobalStyle = createGlobalStyle`
   @import url('https://fonts.googleapis.com/css?family=Nunito+Sans:300,300i,400,400i,700,700i,800,800i&display=swap');
 `;
 
-const HoppinDesignProvider = ({ children, mode, theme }) => {
-  console.log(theme, tokens);
+const HoppinDesignProvider = ({ children, context, theme }) => {
+  // Get theme from the react context.
+  // This is used when we use nested HoppinDesignProviders,
+  // it will inherit the tokens/theme form it's parent, no need to pass in a new theme, just set the context.
+  const themeContext = useContext(ThemeContext);
   // if we specify a theme-override, merge it with the default tokens
-  const tokensWithOverrides = merge({}, tokens, theme);
+  const tokensWithOverrides = merge({}, tokens, themeContext, theme);
   // depending on mode, set the primary colors
-  const tokensWithMode = merge({}, tokens, {
+  const tokensWithContext = merge({}, tokensWithOverrides, {
     colors: get(
-      tokensWithOverrides.colors.modes,
-      mode,
+      tokensWithOverrides.colors.contexts,
+      context,
       tokensWithOverrides.colors
     ),
   });
+
+  console.log('merged tokensWithContext', tokensWithContext);
   return (
-    <ThemeProvider theme={tokensWithMode}>
+    <ThemeProvider theme={tokensWithContext}>
       <React.Fragment>
         <GlobalStyle />
         {children}

--- a/src/components/HoppinDesignProvider/Readme.mdx
+++ b/src/components/HoppinDesignProvider/Readme.mdx
@@ -12,7 +12,7 @@ import { Button } from 'components/Button';
 
 The HoppinDesignProvider should wrap the main App component, it provides the theme to all the siblings.
 
-Make sure to set `mode='host'` or `mode='hopper'` in the to set primary colors, it defaults to `mode='hopper'`.
+Make sure to set `context='host'` or `context='hopper'` in the to set primary colors, it defaults to `context='hopper'`.
 
 - `host` => primary is host pink
 - `hopper` => primary is hopper blue
@@ -27,13 +27,13 @@ Make sure to set `mode='host'` or `mode='hopper'` in the to set primary colors, 
   </HoppinDesignProvider>
 
 <br/>
-<HoppinDesignProvider mode="hopper">
+<HoppinDesignProvider context="hopper">
   <Button variant="full" context="primary">
     Primary Button
   </Button>
 </HoppinDesignProvider>
 <br/>
-  <HoppinDesignProvider mode="host">
+  <HoppinDesignProvider context="host">
     <Button variant="full" context="primary">Primary Button</Button>
   </HoppinDesignProvider>
 </Playground>

--- a/src/tokens/colors.js
+++ b/src/tokens/colors.js
@@ -49,14 +49,24 @@ let colors = {
     darker: '#243b53',
     darkest: '#112233',
   },
+
+  whiteout: {
+    lightest: '#fff',
+    lighter: '#fff',
+    light: '#fff',
+    base: '#fff',
+    dark: '#fff',
+    darker: '#fff',
+    darkest: '#fff',
+  },
 };
 
 // set default "primary" to hopper colors:
 colors.primary = colors.hopper;
 
-// define color modes (like dark and light, in our case hopper and host modes)
-// https://styled-system.com/guides/color-modes
-colors.modes = {
+// define color contexts (like dark and light, in our case hopper and host contexts)
+// https://styled-system.com/guides/color-modes (they call it modes, we call it context to keep it consistent with components-level overrrides (see Button))
+colors.contexts = {
   host: {
     primary: colors.host,
   },

--- a/src/tokens/index.js
+++ b/src/tokens/index.js
@@ -10,13 +10,6 @@ import {
   headings,
 } from './typography';
 
-/* exports theme object.
-   make sure to set mode='host' or mod='hopper' in the HoppinDesignProvider to select primary colors.
-   - 'host'   => primary is host pink
-   - 'hopper' => primary is hopper blue
-
-*/
-
 export default {
   space,
   containerWidths,

--- a/src/tokens/typography.js
+++ b/src/tokens/typography.js
@@ -43,11 +43,11 @@ const fontWeights = {
   bold: 600,
 };
 
+// headings style attributes, all but color, since color is dependent on host/hopper context
 const headings = {
   h1: {
     fontFamily: fonts.primary,
     fontSize: fontSizes.h1,
-    color: colors.primary.base,
     letterSpacing: '-2px',
     lineHeight: lineHeights.base,
     fontWeight: fontWeights.bold,
@@ -57,32 +57,27 @@ const headings = {
   h2: {
     fontFamily: fonts.primary,
     fontSize: fontSizes.h2,
-    color: colors.primary.darker,
     letterSpacing: '-1px',
     fontWeight: fontWeights.bold,
   },
   h3: {
     fontFamily: fonts.primary,
     fontSize: fontSizes.h3,
-    color: colors.neutrals.darker,
     fontWeight: fontWeights.bold,
   },
   h4: {
     fontFamily: fonts.secondary,
     fontSize: fontSizes.h4,
-    color: colors.neutrals.darker,
     fontWeight: fontWeights.normal,
   },
   h5: {
     fontFamily: fonts.secondary,
     fontSize: fontSizes.h5,
-    color: colors.neutrals.dark,
     fontWeight: fontWeights.bold,
   },
   h6: {
     fontFamily: fonts.secondary,
     fontSize: fontSizes.h6,
-    color: colors.neutrals.dark,
     textTransform: 'uppercase',
     fontWeight: fontWeights.bold,
   },


### PR DESCRIPTION
- makes `HoppinDesignProvider` nestable. 
    You can now use as many inside each other and they will pass down the theme properly.
- renames `HoppinDesignProvider`'s `mode` to `context`, so it's consistent with the `context` prop we have on `Button`, etc.

 => Use `context="hopper"` or `context="host" to switch context for all children of the theme provider. 

- Also adds a 'whiteout' context for the buttons. to create white buttons with for dark-colored backgrounds. 
