### PR TITLE
Form Styling Fixes

### DIFF
--- a/es/components/Form/Fields.js
+++ b/es/components/Form/Fields.js
@@ -1,7 +1,6 @@
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _templateObject = _taggedTemplateLiteralLoose(['\n  display: inline-block;\n\n  margin-left: 6px;\n\n  font-size: 12px;\n  line-height: 10px;\n  font-weight: 600;\n  color: ', ';\n'], ['\n  display: inline-block;\n\n  margin-left: 6px;\n\n  font-size: 12px;\n  line-height: 10px;\n  font-weight: 600;\n  color: ', ';\n']),
-    _templateObject2 = _taggedTemplateLiteralLoose(['\n  font-family: ', ';\n  margin: 0;\n  padding: 3px;\n\n  font-size: 12px;\n  line-height: 12px;\n  color: ', ';\n\n  text-align: right;\n'], ['\n  font-family: ', ';\n  margin: 0;\n  padding: 3px;\n\n  font-size: 12px;\n  line-height: 12px;\n  color: ', ';\n\n  text-align: right;\n']);
+var _templateObject = _taggedTemplateLiteralLoose(['\n  margin: 0;\n  padding: 3px;\n\n  font-family: ', ';\n\n  font-size: 12px;\n  line-height: 12px;\n  color: ', ';\n\n  text-align: right;\n'], ['\n  margin: 0;\n  padding: 3px;\n\n  font-family: ', ';\n\n  font-size: 12px;\n  line-height: 12px;\n  color: ', ';\n\n  text-align: right;\n']);
 
 function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
 
@@ -15,30 +14,20 @@ import Async from 'react-select/async';
 import Creatable from 'react-select/creatable';
 
 import getSelectStyling from './SelectStyling';
-import Checkbox from './Checkbox';
-// import Calendar from './Calendar';
-import Input from './Input';
-import Label from './Label';
-import TextareaMd from './TextareaMd';
+import { Checkbox, Input, Label, TextareaMd, RequiredText } from '.';
 
 import { Flex } from '../Flex';
 import { Box } from '../Box';
 import { Button } from '../Button';
+import { Paragraph } from '../Paragraph';
 
 // ---------------------------
 
-export var RequiredText = styled.span(_templateObject, function (_ref) {
+export var RequiredCharacters = styled.p(_templateObject, function (_ref) {
   var theme = _ref.theme;
-  return theme.colors.primary.base;
-});
-
-// ---------------------------
-
-export var RequiredCharacters = styled.p(_templateObject2, function (_ref2) {
-  var theme = _ref2.theme;
   return theme.fonts.secondary;
-}, function (_ref3) {
-  var theme = _ref3.theme;
+}, function (_ref2) {
+  var theme = _ref2.theme;
   return theme.colors.neutral.light;
 });
 
@@ -51,6 +40,11 @@ export var RequiredCharacters = styled.p(_templateObject2, function (_ref2) {
 export var renderField = function renderField(field, _onChange, selectStyling) {
   var charsUsed = field.value ? field.value.length : 0;
 
+  // To reset the margin underneath a field
+  if (field.maxLength && !_has(field, 'props.marginBottom')) {
+    field.props = _extends({}, field.props, { marginBottom: 0 });
+  }
+
   if (field.type === 'textarea') {
     return React.createElement(
       Fragment,
@@ -58,7 +52,8 @@ export var renderField = function renderField(field, _onChange, selectStyling) {
       React.createElement(TextareaMd, _extends({
         name: field.name,
         initialValue: field.value,
-        label: field.title ? undefined : field.label,
+        label: field.label,
+        placeholder: field.placeholder,
         onChange: _onChange.bind(null, field.name),
         context: field.context
       }, field.props)),
@@ -80,8 +75,8 @@ export var renderField = function renderField(field, _onChange, selectStyling) {
       clearValue: function clearValue() {
         return _onChange(field.name, { target: { value: '' } });
       },
-      onChange: function onChange(option, _ref4) {
-        var action = _ref4.action;
+      onChange: function onChange(option, _ref3) {
+        var action = _ref3.action;
 
         if (action === 'select-option' || action === 'create-option' || action === 'remove-value' || action === 'pop-value') {
           return _onChange(field.name, { target: { value: option.value } });
@@ -103,8 +98,8 @@ export var renderField = function renderField(field, _onChange, selectStyling) {
       isMulti: field.type === 'multi-select',
       isClearable: field.type === 'multi-select',
       value: field.value,
-      onChange: function onChange(option, _ref5) {
-        var action = _ref5.action;
+      onChange: function onChange(option, _ref4) {
+        var action = _ref4.action;
 
         if (action === 'select-option' || action === 'remove-value' || action === 'pop-value') {
           return _onChange(field.name, {
@@ -133,8 +128,8 @@ export var renderField = function renderField(field, _onChange, selectStyling) {
     return React.createElement(Async, _extends({
       cacheOptions: false,
       value: field.value,
-      onChange: function onChange(option, _ref6) {
-        var action = _ref6.action;
+      onChange: function onChange(option, _ref5) {
+        var action = _ref5.action;
 
         if (action === 'select-option' || action === 'remove-value' || action === 'pop-value') {
           return _onChange(field.name, {
@@ -207,16 +202,17 @@ export var renderField = function renderField(field, _onChange, selectStyling) {
   return React.createElement(
     Fragment,
     null,
-    React.createElement(Input, {
+    React.createElement(Input, _extends({
       type: field.type,
       value: field.value || '',
       name: field.name,
+      placeholder: field.placeholder,
       label: field.title ? undefined : field.label,
       onChange: _onChange.bind(null, field.name),
       context: field.context,
       renderWidth: field.renderWidth || 'full',
       icon: field.icon
-    }),
+    }, field.props)),
     field.maxLength && React.createElement(
       RequiredCharacters,
       null,
@@ -231,10 +227,10 @@ export var renderField = function renderField(field, _onChange, selectStyling) {
 
 // ---------------------------
 
-var Fields = function Fields(_ref7) {
-  var onChange = _ref7.onChange,
-      fields = _ref7.fields,
-      theme = _ref7.theme;
+var Fields = function Fields(_ref6) {
+  var onChange = _ref6.onChange,
+      fields = _ref6.fields,
+      theme = _ref6.theme;
 
   var selectStyling = getSelectStyling(theme);
 
@@ -246,20 +242,15 @@ var Fields = function Fields(_ref7) {
         Box,
         {
           key: field.name,
-          mb: _has(field, 'marginBottom') ? field.marginBottom : 4
+          marginBottom: _has(field, 'marginBottom') ? field.marginBottom : 'large'
         },
         field.type === 'group' ? React.createElement(
           Fragment,
           null,
           field.title && React.createElement(
-            Label,
+            Paragraph,
             null,
-            field.title,
-            field.required && React.createElement(
-              RequiredText,
-              null,
-              '*required'
-            )
+            field.title
           ),
           React.createElement(
             Flex,
@@ -270,19 +261,9 @@ var Fields = function Fields(_ref7) {
                 {
                   key: field.name + '-' + groupedField.name,
                   flex: 1,
-                  mr: 1,
-                  ml: ix === 0 ? 0 : 1
+                  marginRight: 'xsmall',
+                  marginLeft: ix === 0 ? 'none' : 'xsmall'
                 },
-                groupedField.type && groupedField.title && React.createElement(
-                  Label,
-                  null,
-                  groupedField.title,
-                  groupedField.required && React.createElement(
-                    RequiredText,
-                    null,
-                    '*required'
-                  )
-                ),
                 groupedField.type ? renderField(groupedField, onChange, selectStyling) : null
               );
             })
@@ -291,14 +272,9 @@ var Fields = function Fields(_ref7) {
           Fragment,
           null,
           field.title && React.createElement(
-            Label,
+            Paragraph,
             { paddingTop: 'small', paddingBottom: 'xsmall' },
-            field.title,
-            field.required && React.createElement(
-              RequiredText,
-              null,
-              '*required'
-            )
+            field.title
           ),
           renderField(field, onChange, selectStyling)
         )

--- a/es/components/Form/Input.js
+++ b/es/components/Form/Input.js
@@ -11,8 +11,8 @@ import PropTypes from 'prop-types';
 import styled, { withTheme } from 'styled-components';
 import { typography, space } from 'styled-system';
 
-import Label from './Label';
 import { Box } from '../Box';
+import { Label, RequiredText } from '.';
 
 // ---------------------------
 
@@ -94,8 +94,9 @@ var Input = function Input(_ref8) {
   var _style;
 
   var label = _ref8.label,
+      required = _ref8.required,
       theme = _ref8.theme,
-      rest = _objectWithoutProperties(_ref8, ['label', 'theme']);
+      rest = _objectWithoutProperties(_ref8, ['label', 'required', 'theme']);
 
   var icon = rest.icon,
       iconPosition = rest.iconPosition;
@@ -103,22 +104,26 @@ var Input = function Input(_ref8) {
 
   var LabelOrFragment = label ? Label : Fragment;
   var labelProps = label ? { label: label, htmlFor: rest.name } : {};
-  var inputProps = label ? { marginTop: 'small' } : {};
+  var inputProps = _extends({}, label && { marginTop: 'small' });
   // if we have an icon, we need to have a box gto position the icon
   var WrapperOrFragment = icon ? Box : Fragment;
   var wrapperProps = icon ? { position: 'relative' } : {};
   var iconProps = {
     style: (_style = {
       position: 'absolute',
-      top: '0.85em'
+      top: '0.79em'
     }, _style[iconPosition] = theme.space.base, _style),
     color: theme.colors[rest.context] && theme.colors[rest.context].base || theme.colors.neutral.base
   };
-
   return React.createElement(
     LabelOrFragment,
     labelProps,
     label,
+    label && required && React.createElement(
+      RequiredText,
+      null,
+      '*required'
+    ),
     React.createElement(
       WrapperOrFragment,
       wrapperProps,

--- a/es/components/Form/RequiredText.js
+++ b/es/components/Form/RequiredText.js
@@ -1,0 +1,23 @@
+var _templateObject = _taggedTemplateLiteralLoose(['\n  display: inline-block;\n\n  margin-left: 6px;\n\n  font-size: 12px;\n  line-height: 10px;\n  font-weight: 600;\n\n  color: ', ';\n'], ['\n  display: inline-block;\n\n  margin-left: 6px;\n\n  font-size: 12px;\n  line-height: 10px;\n  font-weight: 600;\n\n  color: ', ';\n']);
+
+function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
+
+// import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+export var RequiredText = styled.span(_templateObject, function (_ref) {
+  var theme = _ref.theme;
+  return theme.colors.primary.base;
+});
+
+RequiredText.propTypes = {
+  // color: PropTypes.string,
+};
+
+RequiredText.defaultProps = {
+  // color: 'primary.base',
+};
+
+RequiredText.displayName = 'RequiredText';
+
+export default RequiredText;

--- a/es/components/Form/TextareaMd/index.js
+++ b/es/components/Form/TextareaMd/index.js
@@ -20,7 +20,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { space, layout, flexbox, fontSize } from 'styled-system';
 
-import Label from '../Label';
+import { Label, RequiredText } from '../.';
 
 import { Editor } from 'slate-react';
 import MarkdownSerializer from 'slate-md-serializer';
@@ -204,6 +204,7 @@ var TextareaMdField = (_temp = _class = function (_React$Component) {
 
     onChange && onChange({
       target: {
+        type: 'textarea',
         name: _this3.props.name,
         value: _this3.markdown.serialize(value)
       }
@@ -217,6 +218,7 @@ var TextareaMdField = (_temp = _class = function (_React$Component) {
 
     onBlur && onBlur({
       target: {
+        type: 'textarea',
         name: _this3.props.name,
         value: _this3.markdown.serialize(_this3.state.value)
       }
@@ -278,16 +280,22 @@ StyledEditor.defaultProps = {
 
 var TextareaMd = function TextareaMd(_ref7) {
   var label = _ref7.label,
-      rest = _objectWithoutProperties(_ref7, ['label']);
+      required = _ref7.required,
+      rest = _objectWithoutProperties(_ref7, ['label', 'required']);
 
-  var Wrapper = label ? Label : Fragment;
-  var wrapperProps = label ? { label: label, htmlFor: rest.name } : {};
-  var inputProps = label ? { marginTop: 'small' } : {};
+  var LabelOrFragment = label ? Label : Fragment;
+  var labelProps = label ? { label: label, htmlFor: rest.name } : {};
+  var textareaProps = label ? { marginTop: 'small' } : {};
   return React.createElement(
-    Wrapper,
-    wrapperProps,
+    LabelOrFragment,
+    labelProps,
     label,
-    React.createElement(TextareaMdField, _extends({}, rest, inputProps))
+    label && required && React.createElement(
+      RequiredText,
+      null,
+      '*required'
+    ),
+    React.createElement(TextareaMdField, _extends({}, rest, textareaProps))
   );
 };
 

--- a/es/components/Form/index.js
+++ b/es/components/Form/index.js
@@ -10,3 +10,5 @@ export { default as RangeSlider } from './RangeSlider';
 export { default as getSelectStyling } from './SelectStyling';
 
 export { default as Fields } from './Fields';
+
+export { default as RequiredText } from './RequiredText';

--- a/es/components/Heading/Heading.js
+++ b/es/components/Heading/Heading.js
@@ -24,31 +24,31 @@ var headingStyles = variant({
 });
 
 var Heading = styled('h2')(_templateObject, headingStyles, function (_ref) {
-  var theme = _ref.theme,
+  var colors = _ref.theme.colors,
       as = _ref.as;
 
   var colorCSS = '';
   switch (as) {
     case 'h1':
-      colorCSS = 'color: ' + theme.colors.primary.base + ';';
+      colorCSS = 'color: ' + colors.primary.base + ';';
       break;
     case 'h2':
-      colorCSS = 'color: ' + theme.colors.primary.base + ';';
+      colorCSS = 'color: ' + colors.primary.base + ';';
       break;
     case 'h3':
-      colorCSS = 'color: ' + theme.colors.neutral.darker + ';';
+      colorCSS = 'color: ' + colors.neutral.darker + ';';
       break;
     case 'h4':
-      colorCSS = 'color: ' + theme.colors.neutral.darker + ';';
+      colorCSS = 'color: ' + colors.neutral.darker + ';';
       break;
     case 'h5':
-      colorCSS = 'color: ' + theme.colors.neutral.dark + ';';
+      colorCSS = 'color: ' + colors.neutral.dark + ';';
       break;
     case 'h6':
-      colorCSS = 'color: ' + theme.colors.neutral.dark + ';';
+      colorCSS = 'color: ' + colors.neutral.dark + ';';
       break;
     default:
-      colorCSS = 'color: ' + theme.colors.primary.base + ';';
+      colorCSS = 'color: ' + colors.primary.base + ';';
       break;
   }
   return colorCSS;

--- a/es/components/Text/Emphasize.js
+++ b/es/components/Text/Emphasize.js
@@ -1,0 +1,33 @@
+var _templateObject = _taggedTemplateLiteralLoose(['\n  display: ', ';\n\n  border: 0px;\n  border-bottom: 4px solid;\n  border-bottom-color: ', ';\n'], ['\n  display: ', ';\n\n  border: 0px;\n  border-bottom: 4px solid;\n  border-bottom-color: ', ';\n']);
+
+function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
+
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import Color from 'color';
+
+import Text from './Text';
+
+var Emphasize = styled(Text)(_templateObject, function (_ref) {
+  var display = _ref.display;
+  return display;
+}, function (_ref2) {
+  var theme = _ref2.theme;
+  return Color(theme.colors.primary.base).alpha('0.45').rgb().string();
+});
+
+Emphasize.propTypes = {
+  display: PropTypes.string,
+  fontWeight: PropTypes.string,
+  lineHeight: PropTypes.string
+};
+
+Emphasize.defaultProps = {
+  display: 'inline-block',
+  fontWeight: '600',
+  lineHeight: '0.75'
+};
+
+Emphasize.displayName = 'Emphasize';
+
+export default Emphasize;

--- a/es/components/Text/Text.js
+++ b/es/components/Text/Text.js
@@ -20,4 +20,5 @@ Text.defaultProps = {
 };
 
 Text.displayName = 'Text';
+
 export default Text;

--- a/es/components/Text/index.js
+++ b/es/components/Text/index.js
@@ -1,1 +1,2 @@
 export { default as Text } from './Text';
+export { default as Emphasize } from './Emphasize';

--- a/lib/components/Form/Fields.js
+++ b/lib/components/Form/Fields.js
@@ -1,12 +1,11 @@
 'use strict';
 
 exports.__esModule = true;
-exports.renderField = exports.RequiredCharacters = exports.RequiredText = undefined;
+exports.renderField = exports.RequiredCharacters = undefined;
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _templateObject = _taggedTemplateLiteralLoose(['\n  display: inline-block;\n\n  margin-left: 6px;\n\n  font-size: 12px;\n  line-height: 10px;\n  font-weight: 600;\n  color: ', ';\n'], ['\n  display: inline-block;\n\n  margin-left: 6px;\n\n  font-size: 12px;\n  line-height: 10px;\n  font-weight: 600;\n  color: ', ';\n']),
-    _templateObject2 = _taggedTemplateLiteralLoose(['\n  font-family: ', ';\n  margin: 0;\n  padding: 3px;\n\n  font-size: 12px;\n  line-height: 12px;\n  color: ', ';\n\n  text-align: right;\n'], ['\n  font-family: ', ';\n  margin: 0;\n  padding: 3px;\n\n  font-size: 12px;\n  line-height: 12px;\n  color: ', ';\n\n  text-align: right;\n']);
+var _templateObject = _taggedTemplateLiteralLoose(['\n  margin: 0;\n  padding: 3px;\n\n  font-family: ', ';\n\n  font-size: 12px;\n  line-height: 12px;\n  color: ', ';\n\n  text-align: right;\n'], ['\n  margin: 0;\n  padding: 3px;\n\n  font-family: ', ';\n\n  font-size: 12px;\n  line-height: 12px;\n  color: ', ';\n\n  text-align: right;\n']);
 
 var _react = require('react');
 
@@ -40,21 +39,7 @@ var _SelectStyling = require('./SelectStyling');
 
 var _SelectStyling2 = _interopRequireDefault(_SelectStyling);
 
-var _Checkbox = require('./Checkbox');
-
-var _Checkbox2 = _interopRequireDefault(_Checkbox);
-
-var _Input = require('./Input');
-
-var _Input2 = _interopRequireDefault(_Input);
-
-var _Label = require('./Label');
-
-var _Label2 = _interopRequireDefault(_Label);
-
-var _TextareaMd = require('./TextareaMd');
-
-var _TextareaMd2 = _interopRequireDefault(_TextareaMd);
+var _ = require('.');
 
 var _Flex = require('../Flex');
 
@@ -62,26 +47,19 @@ var _Box = require('../Box');
 
 var _Button = require('../Button');
 
+var _Paragraph = require('../Paragraph');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
-// import Calendar from './Calendar';
-
 
 // ---------------------------
 
-var RequiredText = exports.RequiredText = _styledComponents2.default.span(_templateObject, function (_ref) {
+var RequiredCharacters = exports.RequiredCharacters = _styledComponents2.default.p(_templateObject, function (_ref) {
   var theme = _ref.theme;
-  return theme.colors.primary.base;
-});
-
-// ---------------------------
-
-var RequiredCharacters = exports.RequiredCharacters = _styledComponents2.default.p(_templateObject2, function (_ref2) {
-  var theme = _ref2.theme;
   return theme.fonts.secondary;
-}, function (_ref3) {
-  var theme = _ref3.theme;
+}, function (_ref2) {
+  var theme = _ref2.theme;
   return theme.colors.neutral.light;
 });
 
@@ -94,14 +72,20 @@ var RequiredCharacters = exports.RequiredCharacters = _styledComponents2.default
 var renderField = exports.renderField = function renderField(field, _onChange, selectStyling) {
   var charsUsed = field.value ? field.value.length : 0;
 
+  // To reset the margin underneath a field
+  if (field.maxLength && !(0, _has3.default)(field, 'props.marginBottom')) {
+    field.props = _extends({}, field.props, { marginBottom: 0 });
+  }
+
   if (field.type === 'textarea') {
     return _react2.default.createElement(
       _react.Fragment,
       null,
-      _react2.default.createElement(_TextareaMd2.default, _extends({
+      _react2.default.createElement(_.TextareaMd, _extends({
         name: field.name,
         initialValue: field.value,
-        label: field.title ? undefined : field.label,
+        label: field.label,
+        placeholder: field.placeholder,
         onChange: _onChange.bind(null, field.name),
         context: field.context
       }, field.props)),
@@ -123,8 +107,8 @@ var renderField = exports.renderField = function renderField(field, _onChange, s
       clearValue: function clearValue() {
         return _onChange(field.name, { target: { value: '' } });
       },
-      onChange: function onChange(option, _ref4) {
-        var action = _ref4.action;
+      onChange: function onChange(option, _ref3) {
+        var action = _ref3.action;
 
         if (action === 'select-option' || action === 'create-option' || action === 'remove-value' || action === 'pop-value') {
           return _onChange(field.name, { target: { value: option.value } });
@@ -146,8 +130,8 @@ var renderField = exports.renderField = function renderField(field, _onChange, s
       isMulti: field.type === 'multi-select',
       isClearable: field.type === 'multi-select',
       value: field.value,
-      onChange: function onChange(option, _ref5) {
-        var action = _ref5.action;
+      onChange: function onChange(option, _ref4) {
+        var action = _ref4.action;
 
         if (action === 'select-option' || action === 'remove-value' || action === 'pop-value') {
           return _onChange(field.name, {
@@ -176,8 +160,8 @@ var renderField = exports.renderField = function renderField(field, _onChange, s
     return _react2.default.createElement(_async2.default, _extends({
       cacheOptions: false,
       value: field.value,
-      onChange: function onChange(option, _ref6) {
-        var action = _ref6.action;
+      onChange: function onChange(option, _ref5) {
+        var action = _ref5.action;
 
         if (action === 'select-option' || action === 'remove-value' || action === 'pop-value') {
           return _onChange(field.name, {
@@ -202,7 +186,7 @@ var renderField = exports.renderField = function renderField(field, _onChange, s
   }
 
   if (field.type === 'checkbox') {
-    return _react2.default.createElement(_Checkbox2.default, {
+    return _react2.default.createElement(_.Checkbox, {
       name: field.name,
       label: field.label,
       checked: field.checked,
@@ -213,7 +197,7 @@ var renderField = exports.renderField = function renderField(field, _onChange, s
 
   if (field.type === 'inline-submit') {
     // if we have a label, wrap input in label add margin-top to input, otherwise no wrapper
-    var LabelOrFragment = field.label ? _Label2.default : _react.Fragment;
+    var LabelOrFragment = field.label ? _.Label : _react.Fragment;
     var labelProps = field.label ? { label: field.title ? undefined : field.label, htmlFor: field.name } : {};
     var flexProps = field.label ? { marginTop: 'small', marginBottom: 'base' } : {};
     var inputProps = field.label ? { marginTop: 'none', marginBottom: 'none' } : {};
@@ -224,7 +208,7 @@ var renderField = exports.renderField = function renderField(field, _onChange, s
       _react2.default.createElement(
         _Flex.Flex,
         flexProps,
-        _react2.default.createElement(_Input2.default, _extends({
+        _react2.default.createElement(_.Input, _extends({
           type: field.type,
           value: field.value || '',
           name: field.name,
@@ -250,16 +234,17 @@ var renderField = exports.renderField = function renderField(field, _onChange, s
   return _react2.default.createElement(
     _react.Fragment,
     null,
-    _react2.default.createElement(_Input2.default, {
+    _react2.default.createElement(_.Input, _extends({
       type: field.type,
       value: field.value || '',
       name: field.name,
+      placeholder: field.placeholder,
       label: field.title ? undefined : field.label,
       onChange: _onChange.bind(null, field.name),
       context: field.context,
       renderWidth: field.renderWidth || 'full',
       icon: field.icon
-    }),
+    }, field.props)),
     field.maxLength && _react2.default.createElement(
       RequiredCharacters,
       null,
@@ -274,10 +259,10 @@ var renderField = exports.renderField = function renderField(field, _onChange, s
 
 // ---------------------------
 
-var Fields = function Fields(_ref7) {
-  var onChange = _ref7.onChange,
-      fields = _ref7.fields,
-      theme = _ref7.theme;
+var Fields = function Fields(_ref6) {
+  var onChange = _ref6.onChange,
+      fields = _ref6.fields,
+      theme = _ref6.theme;
 
   var selectStyling = (0, _SelectStyling2.default)(theme);
 
@@ -289,20 +274,15 @@ var Fields = function Fields(_ref7) {
         _Box.Box,
         {
           key: field.name,
-          mb: (0, _has3.default)(field, 'marginBottom') ? field.marginBottom : 4
+          marginBottom: (0, _has3.default)(field, 'marginBottom') ? field.marginBottom : 'large'
         },
         field.type === 'group' ? _react2.default.createElement(
           _react.Fragment,
           null,
           field.title && _react2.default.createElement(
-            _Label2.default,
+            _Paragraph.Paragraph,
             null,
-            field.title,
-            field.required && _react2.default.createElement(
-              RequiredText,
-              null,
-              '*required'
-            )
+            field.title
           ),
           _react2.default.createElement(
             _Flex.Flex,
@@ -313,19 +293,9 @@ var Fields = function Fields(_ref7) {
                 {
                   key: field.name + '-' + groupedField.name,
                   flex: 1,
-                  mr: 1,
-                  ml: ix === 0 ? 0 : 1
+                  marginRight: 'xsmall',
+                  marginLeft: ix === 0 ? 'none' : 'xsmall'
                 },
-                groupedField.type && groupedField.title && _react2.default.createElement(
-                  _Label2.default,
-                  null,
-                  groupedField.title,
-                  groupedField.required && _react2.default.createElement(
-                    RequiredText,
-                    null,
-                    '*required'
-                  )
-                ),
                 groupedField.type ? renderField(groupedField, onChange, selectStyling) : null
               );
             })
@@ -334,14 +304,9 @@ var Fields = function Fields(_ref7) {
           _react.Fragment,
           null,
           field.title && _react2.default.createElement(
-            _Label2.default,
+            _Paragraph.Paragraph,
             { paddingTop: 'small', paddingBottom: 'xsmall' },
-            field.title,
-            field.required && _react2.default.createElement(
-              RequiredText,
-              null,
-              '*required'
-            )
+            field.title
           ),
           renderField(field, onChange, selectStyling)
         )

--- a/lib/components/Form/Input.js
+++ b/lib/components/Form/Input.js
@@ -20,11 +20,9 @@ var _styledComponents2 = _interopRequireDefault(_styledComponents);
 
 var _styledSystem = require('styled-system');
 
-var _Label = require('./Label');
-
-var _Label2 = _interopRequireDefault(_Label);
-
 var _Box = require('../Box');
+
+var _ = require('.');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -112,31 +110,36 @@ var Input = function Input(_ref8) {
   var _style;
 
   var label = _ref8.label,
+      required = _ref8.required,
       theme = _ref8.theme,
-      rest = _objectWithoutProperties(_ref8, ['label', 'theme']);
+      rest = _objectWithoutProperties(_ref8, ['label', 'required', 'theme']);
 
   var icon = rest.icon,
       iconPosition = rest.iconPosition;
   // if we have a label, wrap input in label add margin-top to input, otherwise no wrapper
 
-  var LabelOrFragment = label ? _Label2.default : _react.Fragment;
+  var LabelOrFragment = label ? _.Label : _react.Fragment;
   var labelProps = label ? { label: label, htmlFor: rest.name } : {};
-  var inputProps = label ? { marginTop: 'small' } : {};
+  var inputProps = _extends({}, label && { marginTop: 'small' });
   // if we have an icon, we need to have a box gto position the icon
   var WrapperOrFragment = icon ? _Box.Box : _react.Fragment;
   var wrapperProps = icon ? { position: 'relative' } : {};
   var iconProps = {
     style: (_style = {
       position: 'absolute',
-      top: '0.85em'
+      top: '0.79em'
     }, _style[iconPosition] = theme.space.base, _style),
     color: theme.colors[rest.context] && theme.colors[rest.context].base || theme.colors.neutral.base
   };
-
   return _react2.default.createElement(
     LabelOrFragment,
     labelProps,
     label,
+    label && required && _react2.default.createElement(
+      _.RequiredText,
+      null,
+      '*required'
+    ),
     _react2.default.createElement(
       WrapperOrFragment,
       wrapperProps,

--- a/lib/components/Form/RequiredText.js
+++ b/lib/components/Form/RequiredText.js
@@ -1,0 +1,32 @@
+'use strict';
+
+exports.__esModule = true;
+exports.RequiredText = undefined;
+
+var _templateObject = _taggedTemplateLiteralLoose(['\n  display: inline-block;\n\n  margin-left: 6px;\n\n  font-size: 12px;\n  line-height: 10px;\n  font-weight: 600;\n\n  color: ', ';\n'], ['\n  display: inline-block;\n\n  margin-left: 6px;\n\n  font-size: 12px;\n  line-height: 10px;\n  font-weight: 600;\n\n  color: ', ';\n']);
+
+var _styledComponents = require('styled-components');
+
+var _styledComponents2 = _interopRequireDefault(_styledComponents);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; } // import PropTypes from 'prop-types';
+
+
+var RequiredText = exports.RequiredText = _styledComponents2.default.span(_templateObject, function (_ref) {
+  var theme = _ref.theme;
+  return theme.colors.primary.base;
+});
+
+RequiredText.propTypes = {
+  // color: PropTypes.string,
+};
+
+RequiredText.defaultProps = {
+  // color: 'primary.base',
+};
+
+RequiredText.displayName = 'RequiredText';
+
+exports.default = RequiredText;

--- a/lib/components/Form/TextareaMd/index.js
+++ b/lib/components/Form/TextareaMd/index.js
@@ -22,9 +22,7 @@ var _styledComponents2 = _interopRequireDefault(_styledComponents);
 
 var _styledSystem = require('styled-system');
 
-var _Label = require('../Label');
-
-var _Label2 = _interopRequireDefault(_Label);
+var _ = require('../.');
 
 var _slateReact = require('slate-react');
 
@@ -253,6 +251,7 @@ var TextareaMdField = (_temp = _class = function (_React$Component) {
 
     onChange && onChange({
       target: {
+        type: 'textarea',
         name: _this3.props.name,
         value: _this3.markdown.serialize(value)
       }
@@ -266,6 +265,7 @@ var TextareaMdField = (_temp = _class = function (_React$Component) {
 
     onBlur && onBlur({
       target: {
+        type: 'textarea',
         name: _this3.props.name,
         value: _this3.markdown.serialize(_this3.state.value)
       }
@@ -327,16 +327,22 @@ StyledEditor.defaultProps = {
 
 var TextareaMd = function TextareaMd(_ref7) {
   var label = _ref7.label,
-      rest = _objectWithoutProperties(_ref7, ['label']);
+      required = _ref7.required,
+      rest = _objectWithoutProperties(_ref7, ['label', 'required']);
 
-  var Wrapper = label ? _Label2.default : _react.Fragment;
-  var wrapperProps = label ? { label: label, htmlFor: rest.name } : {};
-  var inputProps = label ? { marginTop: 'small' } : {};
+  var LabelOrFragment = label ? _.Label : _react.Fragment;
+  var labelProps = label ? { label: label, htmlFor: rest.name } : {};
+  var textareaProps = label ? { marginTop: 'small' } : {};
   return _react2.default.createElement(
-    Wrapper,
-    wrapperProps,
+    LabelOrFragment,
+    labelProps,
     label,
-    _react2.default.createElement(TextareaMdField, _extends({}, rest, inputProps))
+    label && required && _react2.default.createElement(
+      _.RequiredText,
+      null,
+      '*required'
+    ),
+    _react2.default.createElement(TextareaMdField, _extends({}, rest, textareaProps))
   );
 };
 

--- a/lib/components/Form/index.js
+++ b/lib/components/Form/index.js
@@ -83,4 +83,13 @@ Object.defineProperty(exports, 'Fields', {
   }
 });
 
+var _RequiredText = require('./RequiredText');
+
+Object.defineProperty(exports, 'RequiredText', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_RequiredText).default;
+  }
+});
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/lib/components/Heading/Heading.js
+++ b/lib/components/Heading/Heading.js
@@ -36,31 +36,31 @@ var headingStyles = (0, _styledSystem.variant)({
 });
 
 var Heading = (0, _styledComponents2.default)('h2')(_templateObject, headingStyles, function (_ref) {
-  var theme = _ref.theme,
+  var colors = _ref.theme.colors,
       as = _ref.as;
 
   var colorCSS = '';
   switch (as) {
     case 'h1':
-      colorCSS = 'color: ' + theme.colors.primary.base + ';';
+      colorCSS = 'color: ' + colors.primary.base + ';';
       break;
     case 'h2':
-      colorCSS = 'color: ' + theme.colors.primary.base + ';';
+      colorCSS = 'color: ' + colors.primary.base + ';';
       break;
     case 'h3':
-      colorCSS = 'color: ' + theme.colors.neutral.darker + ';';
+      colorCSS = 'color: ' + colors.neutral.darker + ';';
       break;
     case 'h4':
-      colorCSS = 'color: ' + theme.colors.neutral.darker + ';';
+      colorCSS = 'color: ' + colors.neutral.darker + ';';
       break;
     case 'h5':
-      colorCSS = 'color: ' + theme.colors.neutral.dark + ';';
+      colorCSS = 'color: ' + colors.neutral.dark + ';';
       break;
     case 'h6':
-      colorCSS = 'color: ' + theme.colors.neutral.dark + ';';
+      colorCSS = 'color: ' + colors.neutral.dark + ';';
       break;
     default:
-      colorCSS = 'color: ' + theme.colors.primary.base + ';';
+      colorCSS = 'color: ' + colors.primary.base + ';';
       break;
   }
   return colorCSS;

--- a/lib/components/Text/Emphasize.js
+++ b/lib/components/Text/Emphasize.js
@@ -1,0 +1,50 @@
+'use strict';
+
+exports.__esModule = true;
+
+var _templateObject = _taggedTemplateLiteralLoose(['\n  display: ', ';\n\n  border: 0px;\n  border-bottom: 4px solid;\n  border-bottom-color: ', ';\n'], ['\n  display: ', ';\n\n  border: 0px;\n  border-bottom: 4px solid;\n  border-bottom-color: ', ';\n']);
+
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _styledComponents = require('styled-components');
+
+var _styledComponents2 = _interopRequireDefault(_styledComponents);
+
+var _color = require('color');
+
+var _color2 = _interopRequireDefault(_color);
+
+var _Text = require('./Text');
+
+var _Text2 = _interopRequireDefault(_Text);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
+
+var Emphasize = (0, _styledComponents2.default)(_Text2.default)(_templateObject, function (_ref) {
+  var display = _ref.display;
+  return display;
+}, function (_ref2) {
+  var theme = _ref2.theme;
+  return (0, _color2.default)(theme.colors.primary.base).alpha('0.45').rgb().string();
+});
+
+Emphasize.propTypes = {
+  display: _propTypes2.default.string,
+  fontWeight: _propTypes2.default.string,
+  lineHeight: _propTypes2.default.string
+};
+
+Emphasize.defaultProps = {
+  display: 'inline-block',
+  fontWeight: '600',
+  lineHeight: '0.75'
+};
+
+Emphasize.displayName = 'Emphasize';
+
+exports.default = Emphasize;
+module.exports = exports['default'];

--- a/lib/components/Text/Text.js
+++ b/lib/components/Text/Text.js
@@ -32,5 +32,6 @@ Text.defaultProps = {
 };
 
 Text.displayName = 'Text';
+
 exports.default = Text;
 module.exports = exports['default'];

--- a/lib/components/Text/index.js
+++ b/lib/components/Text/index.js
@@ -11,4 +11,13 @@ Object.defineProperty(exports, 'Text', {
   }
 });
 
+var _Emphasize = require('./Emphasize');
+
+Object.defineProperty(exports, 'Emphasize', {
+  enumerable: true,
+  get: function get() {
+    return _interopRequireDefault(_Emphasize).default;
+  }
+});
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoppin-design-system",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "private": true,
   "description": "Design system and shared components for Hoppin.",
   "main": "lib/index.js",

--- a/src/components/Form/Fields.js
+++ b/src/components/Form/Fields.js
@@ -8,28 +8,12 @@ import Async from 'react-select/async';
 import Creatable from 'react-select/creatable';
 
 import getSelectStyling from './SelectStyling';
-import Checkbox from './Checkbox';
-// import Calendar from './Calendar';
-import Input from './Input';
-import Label from './Label';
-import TextareaMd from './TextareaMd';
+import { Checkbox, Input, Label, TextareaMd, RequiredText } from '.';
 
 import { Flex } from '../Flex';
 import { Box } from '../Box';
 import { Button } from '../Button';
-
-// ---------------------------
-
-export const RequiredText = styled.span`
-  display: inline-block;
-
-  margin-left: 6px;
-
-  font-size: 12px;
-  line-height: 10px;
-  font-weight: 600;
-  color: ${({ theme }) => theme.colors.primary.base};
-`;
+import { Paragraph } from '../Paragraph';
 
 // ---------------------------
 
@@ -66,7 +50,8 @@ export const renderField = (field, onChange, selectStyling) => {
         <TextareaMd
           name={field.name}
           initialValue={field.value}
-          label={field.title ? undefined : field.label}
+          label={field.label}
+          placeholder={field.placeholder}
           onChange={onChange.bind(null, field.name)}
           context={field.context}
           {...field.props}
@@ -235,6 +220,7 @@ export const renderField = (field, onChange, selectStyling) => {
         type={field.type}
         value={field.value || ''}
         name={field.name}
+        placeholder={field.placeholder}
         label={field.title ? undefined : field.label}
         onChange={onChange.bind(null, field.name)}
         context={field.context}
@@ -263,33 +249,22 @@ const Fields = ({ onChange, fields, theme }) => {
       {fields.map(field => (
         <Box
           key={field.name}
-          mb={_has(field, 'marginBottom') ? field.marginBottom : 4}
+          marginBottom={
+            _has(field, 'marginBottom') ? field.marginBottom : 'large'
+          }
         >
           {field.type === 'group' ? (
             <Fragment>
-              {field.title && (
-                <Label>
-                  {field.title}
-                  {field.required && <RequiredText>*required</RequiredText>}
-                </Label>
-              )}
+              {field.title && <Paragraph>{field.title}</Paragraph>}
               <Flex>
                 {field.list.length > 0 &&
                   field.list.map((groupedField, ix) => (
                     <Box
                       key={`${field.name}-${groupedField.name}`}
                       flex={1}
-                      mr={1}
-                      ml={ix === 0 ? 0 : 1}
+                      marginRight="xsmall"
+                      marginLeft={ix === 0 ? 'none' : 'xsmall'}
                     >
-                      {groupedField.type && groupedField.title && (
-                        <Label>
-                          {groupedField.title}
-                          {groupedField.required && (
-                            <RequiredText>*required</RequiredText>
-                          )}
-                        </Label>
-                      )}
                       {groupedField.type
                         ? renderField(groupedField, onChange, selectStyling)
                         : null}
@@ -300,10 +275,9 @@ const Fields = ({ onChange, fields, theme }) => {
           ) : (
             <Fragment>
               {field.title && (
-                <Label paddingTop="small" paddingBottom="xsmall">
+                <Paragraph paddingTop="small" paddingBottom="xsmall">
                   {field.title}
-                  {field.required && <RequiredText>*required</RequiredText>}
-                </Label>
+                </Paragraph>
               )}
               {renderField(field, onChange, selectStyling)}
             </Fragment>

--- a/src/components/Form/Fields.js
+++ b/src/components/Form/Fields.js
@@ -55,6 +55,11 @@ export const RequiredCharacters = styled.p`
 export const renderField = (field, onChange, selectStyling) => {
   const charsUsed = field.value ? field.value.length : 0;
 
+  // To reset the margin underneath a field
+  if (field.maxLength && !_has(field, 'props.marginBottom')) {
+    field.props = { ...field.props, marginBottom: 0 };
+  }
+
   if (field.type === 'textarea') {
     return (
       <Fragment>
@@ -235,6 +240,7 @@ export const renderField = (field, onChange, selectStyling) => {
         context={field.context}
         renderWidth={field.renderWidth || 'full'}
         icon={field.icon}
+        {...field.props}
       />
       {field.maxLength && (
         <RequiredCharacters>

--- a/src/components/Form/Fields.js
+++ b/src/components/Form/Fields.js
@@ -34,9 +34,10 @@ export const RequiredText = styled.span`
 // ---------------------------
 
 export const RequiredCharacters = styled.p`
-  font-family: ${({ theme }) => theme.fonts.secondary};
   margin: 0;
   padding: 3px;
+
+  font-family: ${({ theme }) => theme.fonts.secondary};
 
   font-size: 12px;
   line-height: 12px;

--- a/src/components/Form/Input.js
+++ b/src/components/Form/Input.js
@@ -109,7 +109,7 @@ const Input = ({ label, theme, ...rest }) => {
   const iconProps = {
     style: {
       position: 'absolute',
-      top: '0.85em',
+      top: '0.79em',
       [iconPosition]: theme.space.base,
     },
     color:

--- a/src/components/Form/Input.js
+++ b/src/components/Form/Input.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import styled, { withTheme } from 'styled-components';
 import { typography, space } from 'styled-system';
 
-import Label from './Label';
 import { Box } from '../Box';
+import { Label, RequiredText } from '.';
 
 // ---------------------------
 
@@ -97,12 +97,12 @@ InputField.displayName = 'InputField';
 
 // ---------------------------
 
-const Input = ({ label, theme, ...rest }) => {
+const Input = ({ label, required, theme, ...rest }) => {
   const { icon, iconPosition } = rest;
   // if we have a label, wrap input in label add margin-top to input, otherwise no wrapper
   const LabelOrFragment = label ? Label : Fragment;
   const labelProps = label ? { label, htmlFor: rest.name } : {};
-  const inputProps = label ? { marginTop: 'small' } : {};
+  const inputProps = { ...(label && { marginTop: 'small' }) };
   // if we have an icon, we need to have a box gto position the icon
   const WrapperOrFragment = icon ? Box : Fragment;
   const wrapperProps = icon ? { position: 'relative' } : {};
@@ -116,10 +116,10 @@ const Input = ({ label, theme, ...rest }) => {
       (theme.colors[rest.context] && theme.colors[rest.context].base) ||
       theme.colors.neutral.base,
   };
-
   return (
     <LabelOrFragment {...labelProps}>
       {label}
+      {label && required && <RequiredText>*required</RequiredText>}
       <WrapperOrFragment {...wrapperProps}>
         <InputField {...rest} {...inputProps} />
         {icon && React.cloneElement(icon, iconProps)}

--- a/src/components/Form/Readme.mdx
+++ b/src/components/Form/Readme.mdx
@@ -6,6 +6,11 @@ menu: Components
 
 import { useState } from 'react';
 import { Props, Playground } from 'docz';
+import { DateUtils } from 'react-day-picker';
+import Select from 'react-select';
+import { ThemeConsumer } from 'styled-components';
+import { FiLinkedin, FiInstagram, FiMail, FiPhone } from 'react-icons/fi';
+
 import { Flex } from '../Flex';
 import { Box } from '../Box';
 import { Paragraph } from '../Paragraph';
@@ -20,10 +25,6 @@ import RangeSlider from './RangeSlider';
 import getSelectStyling from './SelectStyling';
 import Fields from './Fields';
 import FieldsSortable from './FieldsSortable';
-import { DateUtils } from 'react-day-picker';
-import Select from 'react-select';
-import { ThemeConsumer } from 'styled-components';
-import { FiLinkedin, FiMail, FiPhone } from 'react-icons/fi';
 
 # Form
 
@@ -66,12 +67,13 @@ as well as FieldsWrapper which takes a JSON config object and renders the whole 
             marginBottom="none"
             name="phone"
             type="tel"
-            placeholder="Phone number"
+            placeholder="Phone number (no marginBottom)"
             onChange={onChange}
             value={formData.phone || ''}
             icon={<FiPhone />}
-            label="Phone Number (no marginBottom)"
+            label="Phone Number "
             context="danger"
+            required
           />
         </Box>
         <Box 
@@ -138,6 +140,7 @@ It's pinned to slate.js v0.45 since slate's API changes quite rapidly at the mom
             disableMarks={['deleted', 'code']}
             minHeight={150}
             maxHeight={400}
+            required
           />
         </Box>
         <Box 
@@ -414,6 +417,7 @@ fields = [
     {
       name: 'name',
       type: 'group',
+      title: 'So, what is your name?',
       list: [
         {
           name: 'first_name',
@@ -428,12 +432,6 @@ fields = [
           renderWidth: 'full',
         },
       ],
-    },
-    {
-      name: 'linkedin',
-      type: 'text',
-      label: 'LinkedIn Profile URL',
-      icon: <FiLinkedin />
     },
     {
       name: 'pitch',
@@ -480,30 +478,46 @@ Field objects need to have a key `type` with one of the following values:
       {
         name: 'name',
         type: 'group',
+        title: 'So, what is your name?',
+        required: true,
         list: [
           {
             name: 'first_name',
             type: 'text',
-            title: 'First Name',
-            label: 'First Name',
+            label: 'Your first name',
+            placeholder: 'First name',
             required: true,
             renderWidth: 'full',
           },
           {
             name: 'last_name',
             type: 'text',
-            title: 'Last Name',
-            label: 'Last Name',
+            label: 'Your surname',
+            placeholder: 'Last Name',
             required: true,
             renderWidth: 'full',
           },
         ],
       },
       {
-        name: 'linkedin',
-        type: 'text',
-        label: 'LinkedIn Profile URL',
-        icon: <FiLinkedin />
+      name: 'name',
+      type: 'group',
+      title: 'Socials...',
+      list: [
+          {
+            name: 'instagram',
+            type: 'text',
+            label: 'Instagram',
+            required: true,
+            icon: <FiInstagram />
+          },
+          {
+            name: 'linkedin',
+            type: 'text',
+            label: 'LinkedIn Profile URL',
+            icon: <FiLinkedin />
+          },
+        ],
       },
       {
         name: 'pitch',

--- a/src/components/Form/Readme.mdx
+++ b/src/components/Form/Readme.mdx
@@ -574,6 +574,38 @@ Field objects need to have a key `type` with one of the following values:
 }}
 </Playground>
 
+Can also be used to provide more styling to individual fields (such as: `maxLength`)
+
+<Playground>
+  {() => {
+    const fieldsConfig = [
+      {
+        name: 'linkedin',
+        type: 'text',
+        label: 'LinkedIn Profile URL',
+        icon: <FiLinkedin />,
+        maxLength: 70
+      },
+      {
+        name: 'pitch',
+        type: 'textarea',
+        title:
+          'Pitch me baby, one more time! You got 30 seconds or 100 words. Go.',
+        label: 'Your Pitch',
+        required: true,
+        maxLength: 300,
+        props: { minHeight: '100px' }
+      }
+    ];
+    const handleChange = (fieldName, event) => {
+      console.log(event.target)
+    }
+    return (
+      <Fields fields={fieldsConfig} onChange={handleChange} />
+    );
+}}
+</Playground>
+
 ## Sortable Drag&Drop Fields
 
 <Props of={FieldsSortable} />

--- a/src/components/Form/Readme.mdx
+++ b/src/components/Form/Readme.mdx
@@ -57,25 +57,10 @@ as well as FieldsWrapper which takes a JSON config object and renders the whole 
           />
           <Input
             name="email"
-            label="Email address"
-            placeholder="Email"
+            placeholder="Email (no label)"
             onChange={onChange}
             icon={<FiMail />}
             value={formData.email || ''}
-          />
-          <Input
-            name="no_label"
-            placeholder="No label"
-            onChange={onChange}
-            value={formData.no_label || ''}
-          />
-          <Input
-            name="linkedin"
-            placeholder="LinkedIn Profile URL"
-            onChange={onChange}
-            value={formData.linkedin || ''}
-            icon={<FiLinkedin />}
-            label="LinkedIn Profile URL"
           />
           <Input
             marginBottom="none"
@@ -131,20 +116,57 @@ It's pinned to slate.js v0.45 since slate's API changes quite rapidly at the mom
 
 <Playground>
   {() => {
-    const [value, setValue] = useState('Write something **bold**!');
+    const [formData, setFormData] = useState({ veryRichText: 'Write something **bold**!' });
+    const [lastEvent, setLastEvent] = useState({});
+    const onChange = (e) => {
+      setLastEvent(e.target);
+      const { name, value, type, checked } = e.target;
+      setFormData({ ...formData, [name]: type === 'checkbox' ? checked : value })
+    }
     return (
-      <TextareaMd
-        label="Write something exciting"
-        initialValue={value}
-        onChange={e => setValue(e.target.value)}
-        onBlur={e =>
-          console.log('editor lost focus, last value:', e.target.value)
-        }
-        enableBlocks={['paragraph']}
-        disableMarks={['deleted', 'code']}
-        minHeight={150}
-        maxHeight={400}
-      />
+      <Flex>
+        <Box margin="base" padding="base" maxWidth="500px">
+          <TextareaMd
+            name="veryRichText"
+            label="Write something exciting"
+            initialValue={formData.veryRichText || ''}
+            onChange={onChange}
+            onBlur={e =>
+              console.log('editor lost focus, last value:', e.target.value)
+            }
+            enableBlocks={['paragraph']}
+            disableMarks={['deleted', 'code']}
+            minHeight={150}
+            maxHeight={400}
+          />
+        </Box>
+        <Box 
+          margin="base" 
+          padding="base" 
+          maxWidth="300px" 
+          bg="neutral.darker" 
+          color="white" 
+          borderRadius="5px"
+        >
+          <Paragraph>
+            Last event
+          </Paragraph>
+          <UnorderedList>
+            <ListItem>
+              type: {lastEvent.type}
+            </ListItem>
+            <ListItem>
+              name: {lastEvent.name}
+            </ListItem>
+            <ListItem>
+              value: {lastEvent.value}
+            </ListItem>
+            <ListItem>
+              checked: {lastEvent.checked ? 'true': 'false' }
+            </ListItem>
+          </UnorderedList>
+        </Box>
+      </Flex>
     );
   }}
 </Playground>

--- a/src/components/Form/RequiredText.js
+++ b/src/components/Form/RequiredText.js
@@ -1,0 +1,26 @@
+// import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+export const RequiredText = styled.span`
+  display: inline-block;
+
+  margin-left: 6px;
+
+  font-size: 12px;
+  line-height: 10px;
+  font-weight: 600;
+
+  color: ${({ theme }) => theme.colors.primary.base};
+`;
+
+RequiredText.propTypes = {
+  // color: PropTypes.string,
+};
+
+RequiredText.defaultProps = {
+  // color: 'primary.base',
+};
+
+RequiredText.displayName = 'RequiredText';
+
+export default RequiredText;

--- a/src/components/Form/TextareaMd/index.js
+++ b/src/components/Form/TextareaMd/index.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { space, layout, flexbox, fontSize } from 'styled-system';
 
-import Label from '../Label';
+import { Label, RequiredText } from '../.';
 
 import { Editor } from 'slate-react';
 import MarkdownSerializer from 'slate-md-serializer';
@@ -269,15 +269,16 @@ StyledEditor.defaultProps = {
 
 // ---------------------------
 
-const TextareaMd = ({ label, ...rest }) => {
-  const Wrapper = label ? Label : Fragment;
-  const wrapperProps = label ? { label, htmlFor: rest.name } : {};
-  const inputProps = label ? { marginTop: 'small' } : {};
+const TextareaMd = ({ label, required, ...rest }) => {
+  const LabelOrFragment = label ? Label : Fragment;
+  const labelProps = label ? { label, htmlFor: rest.name } : {};
+  const textareaProps = label ? { marginTop: 'small' } : {};
   return (
-    <Wrapper {...wrapperProps}>
+    <LabelOrFragment {...labelProps}>
       {label}
-      <TextareaMdField {...rest} {...inputProps} />
-    </Wrapper>
+      {label && required && <RequiredText>*required</RequiredText>}
+      <TextareaMdField {...rest} {...textareaProps} />
+    </LabelOrFragment>
   );
 };
 

--- a/src/components/Form/TextareaMd/index.js
+++ b/src/components/Form/TextareaMd/index.js
@@ -157,6 +157,7 @@ class TextareaMdField extends React.Component {
     onChange &&
       onChange({
         target: {
+          type: 'textarea',
           name: this.props.name,
           value: this.markdown.serialize(value),
         },
@@ -170,6 +171,7 @@ class TextareaMdField extends React.Component {
     onBlur &&
       onBlur({
         target: {
+          type: 'textarea',
           name: this.props.name,
           value: this.markdown.serialize(this.state.value),
         },

--- a/src/components/Form/index.js
+++ b/src/components/Form/index.js
@@ -10,3 +10,5 @@ export { default as RangeSlider } from './RangeSlider';
 export { default as getSelectStyling } from './SelectStyling';
 
 export { default as Fields } from './Fields';
+
+export { default as RequiredText } from './RequiredText';

--- a/src/components/Heading/Heading.js
+++ b/src/components/Heading/Heading.js
@@ -35,29 +35,29 @@ const Heading = styled('h2')`
   /* use styled-system variants defined in tokens/typography */
   ${headingStyles}
   /* get color from theme to get dymanic context colors (host vs shadower)*/
-  ${({ theme, as }) => {
+  ${({ theme: { colors }, as }) => {
     let colorCSS = '';
     switch (as) {
       case 'h1':
-        colorCSS = `color: ${theme.colors.primary.base};`;
+        colorCSS = `color: ${colors.primary.base};`;
         break;
       case 'h2':
-        colorCSS = `color: ${theme.colors.primary.base};`;
+        colorCSS = `color: ${colors.primary.base};`;
         break;
       case 'h3':
-        colorCSS = `color: ${theme.colors.neutral.darker};`;
+        colorCSS = `color: ${colors.neutral.darker};`;
         break;
       case 'h4':
-        colorCSS = `color: ${theme.colors.neutral.darker};`;
+        colorCSS = `color: ${colors.neutral.darker};`;
         break;
       case 'h5':
-        colorCSS = `color: ${theme.colors.neutral.dark};`;
+        colorCSS = `color: ${colors.neutral.dark};`;
         break;
       case 'h6':
-        colorCSS = `color: ${theme.colors.neutral.dark};`;
+        colorCSS = `color: ${colors.neutral.dark};`;
         break;
       default:
-        colorCSS = `color: ${theme.colors.primary.base};`;
+        colorCSS = `color: ${colors.primary.base};`;
         break;
     }
     return colorCSS;

--- a/src/components/Text/Emphasize.js
+++ b/src/components/Text/Emphasize.js
@@ -1,0 +1,33 @@
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import Color from 'color';
+
+import Text from './Text';
+
+const Emphasize = styled(Text)`
+  display: ${({ display }) => display};
+
+  border: 0px;
+  border-bottom: 4px solid;
+  border-bottom-color: ${({ theme }) =>
+    Color(theme.colors.primary.base)
+      .alpha('0.45')
+      .rgb()
+      .string()};
+`;
+
+Emphasize.propTypes = {
+  display: PropTypes.string,
+  fontWeight: PropTypes.string,
+  lineHeight: PropTypes.string,
+};
+
+Emphasize.defaultProps = {
+  display: 'inline-block',
+  fontWeight: '600',
+  lineHeight: '0.75',
+};
+
+Emphasize.displayName = 'Emphasize';
+
+export default Emphasize;

--- a/src/components/Text/Readme.mdx
+++ b/src/components/Text/Readme.mdx
@@ -6,30 +6,56 @@ menu: Components
 
 import { Props, Playground } from "docz";
 import { Paragraph } from "../Paragraph";
-import { Text } from ".";
+import { Text, Emphasize } from ".";
 
 # Text
 
+## Text (Default)
+
 The Text is used for marking up text. It inherites the style from it's parent, but can be overridden, say to change the `color`, `fontWeight`,...
 
-## Props
+### Props
 
 <Props of={Text} />
 Props table might not render due to a [bug in docz](https://github.com/pedronauck/docz/issues/777)
 
-If you need more options, consider using [Text](components/Text) or [Heading](components/Heading) instead.
+If you need more options, consider using [Paragraph](components/Paragraph) or [Heading](components/Heading) instead.
 
 <Playground>
   <Paragraph>
-    Lorem ipsum dolor amet{" "}
+    Lorem ipsum dolor amet{' '}
     <Text color="primary.dark" fontWeight="bold">
       photo booth
-    </Text>{" "}
+    </Text>{' '}
     scenester cornhole trust fund vaporware williamsburg. Selfies tbh tumeric
     XOXO man braid cred. Skateboard heirloom locavore, kogi everyday carry af
     tattooed art party asymmetrical cardigan sustainable. Tbh cornhole
     post-ironic, literally hashtag ethical adaptogen brooklyn bushwick
     distillery. Vape stumptown swag glossier small batch gastropub. Taxidermy
     90's everyday carry kombucha. Banjo VHS occupy marfa roof party slow-carb.
+  </Paragraph>
+</Playground>
+
+## Emphasize
+
+To allow us to 'emphasize' text. For now the default (and only supported color the `primary.base`).
+
+### Props
+
+<Props of={Emphasize} />
+Props table might not render due to a [bug in docz](https://github.com/pedronauck/docz/issues/777)
+
+<Playground>
+  <Paragraph>
+    Lorem ipsum dolor amet{' '}
+    <Emphasize>
+      photo booth
+    </Emphasize>{' '}
+    scenester cornhole trust fund vaporware williamsburg. 
+    <Emphasize color="neutral.base">
+      Selfies tbh tumeric
+    </Emphasize>{' '}
+    XOXO man braid cred. Skateboard heirloom locavore, kogi everyday carry af
+    tattooed art party asymmetrical cardigan sustainable.
   </Paragraph>
 </Playground>

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -25,4 +25,5 @@ Text.defaultProps = {
 };
 
 Text.displayName = 'Text';
+
 export default Text;

--- a/src/components/Text/index.js
+++ b/src/components/Text/index.js
@@ -1,1 +1,2 @@
 export { default as Text } from './Text';
+export { default as Emphasize } from './Emphasize';


### PR DESCRIPTION
✅ **DONE**:
- [x] Icon alignment (rendering differs on docz vs app)
- [x] Add an emphasis span for 'highlighting'
<img width="490" alt="image" src="https://user-images.githubusercontent.com/6073340/71716639-b4c19d80-2e15-11ea-84c4-2b6d1f3234bd.png">
<img width="393" alt="image" src="https://user-images.githubusercontent.com/6073340/71716614-a2476400-2e15-11ea-8ab3-54cd070597d7.png">
- [x] `maxLength` for `TextareaMd` and `Input` too far underneath the field
<img width="658" alt="image" src="https://user-images.githubusercontent.com/6073340/71716576-89d74980-2e15-11ea-9393-c516a4a2a1af.png">
- [x] Title vs Label
<img width="648" alt="image" src="https://user-images.githubusercontent.com/6073340/71716580-8fcd2a80-2e15-11ea-9771-c2f0bbcd6a94.png">
- [x] Bump: `v1.0.5`

⏹ **TODO**: