### PR TITLE
⏳ Bugfix: TextareaMd Placeholder

### DIFF
--- a/src/components/Form/Fields.js
+++ b/src/components/Form/Fields.js
@@ -8,7 +8,7 @@ import Async from 'react-select/async';
 import Creatable from 'react-select/creatable';
 
 import getSelectStyling from './SelectStyling';
-import { Checkbox, Input, Label, TextareaMd, RequiredText } from '.';
+import { Checkbox, Input, Label, TextareaMd } from '.';
 
 import { Flex } from '../Flex';
 import { Box } from '../Box';

--- a/src/components/Form/Readme.mdx
+++ b/src/components/Form/Readme.mdx
@@ -131,7 +131,8 @@ It's pinned to slate.js v0.45 since slate's API changes quite rapidly at the mom
           <TextareaMd
             name="veryRichText"
             label="Write something exciting"
-            initialValue={formData.veryRichText || ''}
+            // initialValue={formData.veryRichText || ''}
+            placeholder="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua"
             onChange={onChange}
             onBlur={e =>
               console.log('editor lost focus, last value:', e.target.value)

--- a/src/components/Form/TextareaMd/index.js
+++ b/src/components/Form/TextareaMd/index.js
@@ -221,6 +221,7 @@ class TextareaMdField extends React.Component {
 const StyledEditor = styled(Editor)`
   box-sizing: border-box;
   display: block;
+  position: relative;
 
   ${space}
   ${layout}
@@ -256,6 +257,10 @@ const StyledEditor = styled(Editor)`
       initialValue && initialValue.length > 0
         ? theme.colors.whiteout.base
         : theme.colors.whiteout.light};
+  }
+
+  & > p {
+    overflow-wrap: break-word;
   }
 `;
 


### PR DESCRIPTION
@jonashaefele would love for you to have a look at this. A long placeholder in the `TextareaMd` overflows the editor. I tried to figure it out myself, by my css knowledge fails this test 🙈 

<img width="731" alt="image" src="https://user-images.githubusercontent.com/6073340/71785327-8e128b00-2ffe-11ea-8fee-3cae6c62de5c.png">
