### PR TITLE
add: breakpoints and media queries to theme

### DIFF
--- a/es/components/Form/Fields.js
+++ b/es/components/Form/Fields.js
@@ -14,7 +14,7 @@ import Async from 'react-select/async';
 import Creatable from 'react-select/creatable';
 
 import getSelectStyling from './SelectStyling';
-import { Checkbox, Input, Label, TextareaMd, RequiredText } from '.';
+import { Checkbox, Input, Label, TextareaMd } from '.';
 
 import { Flex } from '../Flex';
 import { Box } from '../Box';

--- a/es/tokens/index.js
+++ b/es/tokens/index.js
@@ -1,5 +1,5 @@
 import { colors } from './colors';
-import { space, containerWidths, radii, zIndices } from './space';
+import { space, containerWidths, radii, zIndices, breakpoints, mediaQueries } from './space';
 import { buttonSizes, buttonIconSpacing } from './buttons';
 import { shadows } from './shadows';
 import { fonts, fontSizes, lineHeights, fontWeights, headings } from './typography';
@@ -8,6 +8,8 @@ import { logo, icon } from './logos';
 export default {
   space: space,
   containerWidths: containerWidths,
+  breakpoints: breakpoints,
+  mediaQueries: mediaQueries,
   radii: radii,
   zIndices: zIndices,
   fonts: fonts,

--- a/es/tokens/space.js
+++ b/es/tokens/space.js
@@ -42,4 +42,16 @@ zIndices.front = zIndices[3];
 zIndices.nav = zIndices[4];
 zIndices.overlay = zIndices[5];
 
-export { space, containerWidths, radii, zIndices };
+// breakpoints are mobile-first use no breakpoint to target phones and up
+var breakpoints = ['40em', '52em', '64em'];
+breakpoints.small = breakpoints[0]; // tablets
+breakpoints.medium = breakpoints[1]; // large tablets, desktop
+breakpoints.large = breakpoints[2]; // big screens
+
+var mediaQueries = ['@media screen and (min-width: ' + breakpoints[0] + ')', '@media screen and (min-width: ' + breakpoints[1] + ')', '@media screen and (min-width: ' + breakpoints[2] + ')'];
+
+mediaQueries.small = mediaQueries[0]; // tablets
+mediaQueries.medium = mediaQueries[1]; // large tablets, desktop
+mediaQueries.large = mediaQueries[2]; // big screens
+
+export { space, containerWidths, radii, zIndices, breakpoints, mediaQueries };

--- a/lib/tokens/index.js
+++ b/lib/tokens/index.js
@@ -17,6 +17,8 @@ var _logos = require('./logos');
 exports.default = {
   space: _space.space,
   containerWidths: _space.containerWidths,
+  breakpoints: _space.breakpoints,
+  mediaQueries: _space.mediaQueries,
   radii: _space.radii,
   zIndices: _space.zIndices,
   fonts: _typography.fonts,

--- a/lib/tokens/space.js
+++ b/lib/tokens/space.js
@@ -45,7 +45,21 @@ zIndices.front = zIndices[3];
 zIndices.nav = zIndices[4];
 zIndices.overlay = zIndices[5];
 
+// breakpoints are mobile-first use no breakpoint to target phones and up
+var breakpoints = ['40em', '52em', '64em'];
+breakpoints.small = breakpoints[0]; // tablets
+breakpoints.medium = breakpoints[1]; // large tablets, desktop
+breakpoints.large = breakpoints[2]; // big screens
+
+var mediaQueries = ['@media screen and (min-width: ' + breakpoints[0] + ')', '@media screen and (min-width: ' + breakpoints[1] + ')', '@media screen and (min-width: ' + breakpoints[2] + ')'];
+
+mediaQueries.small = mediaQueries[0]; // tablets
+mediaQueries.medium = mediaQueries[1]; // large tablets, desktop
+mediaQueries.large = mediaQueries[2]; // big screens
+
 exports.space = space;
 exports.containerWidths = containerWidths;
 exports.radii = radii;
 exports.zIndices = zIndices;
+exports.breakpoints = breakpoints;
+exports.mediaQueries = mediaQueries;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoppin-design-system",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "private": true,
   "description": "Design system and shared components for Hoppin.",
   "main": "lib/index.js",

--- a/src/components/Form/Fields.js
+++ b/src/components/Form/Fields.js
@@ -8,7 +8,7 @@ import Async from 'react-select/async';
 import Creatable from 'react-select/creatable';
 
 import getSelectStyling from './SelectStyling';
-import { Checkbox, Input, Label, TextareaMd, RequiredText } from '.';
+import { Checkbox, Input, Label, TextareaMd } from '.';
 
 import { Flex } from '../Flex';
 import { Box } from '../Box';

--- a/src/tokens/index.js
+++ b/src/tokens/index.js
@@ -1,5 +1,12 @@
 import { colors } from './colors';
-import { space, containerWidths, radii, zIndices } from './space';
+import {
+  space,
+  containerWidths,
+  radii,
+  zIndices,
+  breakpoints,
+  mediaQueries,
+} from './space';
 import { buttonSizes, buttonIconSpacing } from './buttons';
 import { shadows } from './shadows';
 import {
@@ -14,6 +21,8 @@ import { logo, icon } from './logos';
 export default {
   space,
   containerWidths,
+  breakpoints,
+  mediaQueries,
   radii,
   zIndices,
   fonts,

--- a/src/tokens/space.js
+++ b/src/tokens/space.js
@@ -45,4 +45,20 @@ zIndices.front = zIndices[3];
 zIndices.nav = zIndices[4];
 zIndices.overlay = zIndices[5];
 
-export { space, containerWidths, radii, zIndices };
+// breakpoints are mobile-first use no breakpoint to target phones and up
+const breakpoints = ['40em', '52em', '64em'];
+breakpoints.small = breakpoints[0]; // tablets
+breakpoints.medium = breakpoints[1]; // large tablets, desktop
+breakpoints.large = breakpoints[2]; // big screens
+
+const mediaQueries = [
+  `@media screen and (min-width: ${breakpoints[0]})`,
+  `@media screen and (min-width: ${breakpoints[1]})`,
+  `@media screen and (min-width: ${breakpoints[2]})`,
+];
+
+mediaQueries.small = mediaQueries[0]; // tablets
+mediaQueries.medium = mediaQueries[1]; // large tablets, desktop
+mediaQueries.large = mediaQueries[2]; // big screens
+
+export { space, containerWidths, radii, zIndices, breakpoints, mediaQueries };

--- a/src/tokens/space.mdx
+++ b/src/tokens/space.mdx
@@ -38,3 +38,39 @@ To minimize random problems with z-index clashes, please set the z-indexes with 
 ## ContainerWidths
 
 Only to be used with [Container](/components/Container). See the docs for the component.
+
+## Breakpoints and Media Queries
+
+All styles are defined mobile-first. Meaning the default styles are set for tiny (phone) screens and media queries are used to add specific styles for larger screens.
+
+The [styled system docs on responsive styles](https://styled-system.com/responsive-styles) explain really well how this works.
+
+If you need to access the breakpoints directly, they are available as `theme.breakpoints` in the theme object.
+
+There are three breakpoints:
+- `theme.breakpoints[0]` or `theme.breakpoints.small` - for huge phones or small tablets
+- `theme.breakpoints[1]` or `theme.breakpoints.medium` - for tablets and smaller desktop windows
+- `theme.breakpoints[2]` or `theme.breakpoints.large` - for iPad Pros and large desktop windows
+
+For convenience, there's also a 'mediaQueries' object in the theme.
+
+Use it like:
+
+```
+styled.div`
+  ${/* default styles (mobile)*/}
+  color: blue;
+
+  ${/* get the media query for medium screens (desktop) and override styles */}
+
+   ${({theme}) => theme.mediaQueries.medium} {
+       color: red;
+   }
+
+  ${/* you can also use the array index [0,1,2] (below gets 2 / large) */}
+
+   ${({theme}) => theme.mediaQueries[2]} {
+       color: red;
+   }
+`
+```


### PR DESCRIPTION
we didn't explicitly define breakpoints, which tells styled-system to use the default ones.

But these can't be accessed in custom styled-components styles. Just with the styled-system props like `width={['100%', '60%', '30%']}`

This adds the breakpoints to the theme and adds convenience getters for media queries.

https://design-system-241no0ce7.now.sh/tokens/Spacing#breakpoints-and-media-queries