### PR TITLE
update: print background for image Tile

### DIFF
--- a/es/components/Image/Tile.js
+++ b/es/components/Image/Tile.js
@@ -1,4 +1,4 @@
-var _templateObject = _taggedTemplateLiteralLoose(['\n  /* \n    Determine the sizing. It always fills the \n    width and adjusts the height accordingly \n  */\n  width: 100%;\n\n  ', '\n\n  ', ' \n  background-size: cover;\n  background-position: center;\n'], ['\n  /* \n    Determine the sizing. It always fills the \n    width and adjusts the height accordingly \n  */\n  width: 100%;\n\n  ', '\n\n  ', ' \n  background-size: cover;\n  background-position: center;\n']);
+var _templateObject = _taggedTemplateLiteralLoose(['\n  /* \n    Determine the sizing. It always fills the \n    width and adjusts the height accordingly \n  */\n  width: 100%;\n\n  ', '\n\n  ', ' \n  background-size: cover;\n  background-position: center;\n\n  ', '\n  -webkit-print-color-adjust: exact;\n  print-color-adjust: exact;\n  color-adjust: exact;\n'], ['\n  /* \n    Determine the sizing. It always fills the \n    width and adjusts the height accordingly \n  */\n  width: 100%;\n\n  ', '\n\n  ', ' \n  background-size: cover;\n  background-position: center;\n\n  ', '\n  -webkit-print-color-adjust: exact;\n  print-color-adjust: exact;\n  color-adjust: exact;\n']);
 
 function _taggedTemplateLiteralLoose(strings, raw) { strings.raw = raw; return strings; }
 
@@ -18,7 +18,7 @@ var Tile = styled(Box)(_templateObject, variant({
 }), function (_ref) {
   var src = _ref.src;
   return src && src !== '' ? 'background-image: url(' + src + ');' : '';
-});
+}, '' /* Print bg image, otherwise there's funny white spaces */);
 
 Tile.propTypes = {
   src: PropTypes.string.isRequired,

--- a/lib/components/Image/Tile.js
+++ b/lib/components/Image/Tile.js
@@ -2,7 +2,7 @@
 
 exports.__esModule = true;
 
-var _templateObject = _taggedTemplateLiteralLoose(['\n  /* \n    Determine the sizing. It always fills the \n    width and adjusts the height accordingly \n  */\n  width: 100%;\n\n  ', '\n\n  ', ' \n  background-size: cover;\n  background-position: center;\n'], ['\n  /* \n    Determine the sizing. It always fills the \n    width and adjusts the height accordingly \n  */\n  width: 100%;\n\n  ', '\n\n  ', ' \n  background-size: cover;\n  background-position: center;\n']);
+var _templateObject = _taggedTemplateLiteralLoose(['\n  /* \n    Determine the sizing. It always fills the \n    width and adjusts the height accordingly \n  */\n  width: 100%;\n\n  ', '\n\n  ', ' \n  background-size: cover;\n  background-position: center;\n\n  ', '\n  -webkit-print-color-adjust: exact;\n  print-color-adjust: exact;\n  color-adjust: exact;\n'], ['\n  /* \n    Determine the sizing. It always fills the \n    width and adjusts the height accordingly \n  */\n  width: 100%;\n\n  ', '\n\n  ', ' \n  background-size: cover;\n  background-position: center;\n\n  ', '\n  -webkit-print-color-adjust: exact;\n  print-color-adjust: exact;\n  color-adjust: exact;\n']);
 
 var _propTypes = require('prop-types');
 
@@ -30,7 +30,7 @@ var Tile = (0, _styledComponents2.default)(_Box.Box)(_templateObject, (0, _style
 }), function (_ref) {
   var src = _ref.src;
   return src && src !== '' ? 'background-image: url(' + src + ');' : '';
-});
+}, '' /* Print bg image, otherwise there's funny white spaces */);
 
 Tile.propTypes = {
   src: _propTypes2.default.string.isRequired,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hoppin-design-system",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "description": "Design system and shared components for Hoppin.",
   "main": "lib/index.js",

--- a/src/components/Image/Avatar.js
+++ b/src/components/Image/Avatar.js
@@ -21,6 +21,7 @@ const Wrapper = styled(Box)`
 const Avatar = ({ src, size, squared, ...rest }) => (
   <Wrapper size={size} {...rest}>
     <Tile src={src} ratio="1/1" borderRadius={squared ? '12px' : '50%'} />
+    {/* TODO: use border radius from theme, why 12px? */}
   </Wrapper>
 );
 

--- a/src/components/Image/Tile.js
+++ b/src/components/Image/Tile.js
@@ -26,6 +26,11 @@ const Tile = styled(Box)`
       : ''} 
   background-size: cover;
   background-position: center;
+
+  ${'' /* Print bg image, otherwise there's funny white spaces */}
+  -webkit-print-color-adjust: exact;
+  print-color-adjust: exact;
+  color-adjust: exact;
 `;
 
 Tile.propTypes = {


### PR DESCRIPTION
Tiles and Avatars use background images which don't get printed by default. These rules make most browsers print them... (it's all still very 1990 unstandardized when it comes to printing) 