### PR TITLE
Fix button group margins for flex wrap

### DIFF
--- a/es/components/Button/ButtonGroup.js
+++ b/es/components/Button/ButtonGroup.js
@@ -16,7 +16,7 @@ var ButtonGroup = styled(Flex)(_templateObject, function (_ref) {
       flexDirection = _ref.flexDirection;
 
   if (flexDirection === 'row') {
-    return Button + ' + ' + Button + ' {\n        margin-left: ' + theme.space.small + ';\n      }';
+    return Button + ':not(:last-child) {\n        margin-right: ' + theme.space.small + '\n      }';
   } else {
     return Button + ' + ' + Button + ' {\n        margin-top: ' + theme.space.small + ';\n      }';
   }

--- a/lib/components/Button/ButtonGroup.js
+++ b/lib/components/Button/ButtonGroup.js
@@ -27,7 +27,7 @@ var ButtonGroup = (0, _styledComponents2.default)(_Flex.Flex)(_templateObject, f
       flexDirection = _ref.flexDirection;
 
   if (flexDirection === 'row') {
-    return _Button2.default + ' + ' + _Button2.default + ' {\n        margin-left: ' + theme.space.small + ';\n      }';
+    return _Button2.default + ':not(:last-child) {\n        margin-right: ' + theme.space.small + '\n      }';
   } else {
     return _Button2.default + ' + ' + _Button2.default + ' {\n        margin-top: ' + theme.space.small + ';\n      }';
   }

--- a/src/components/Button/ButtonGroup.js
+++ b/src/components/Button/ButtonGroup.js
@@ -10,8 +10,8 @@ import Button from './Button';
 const ButtonGroup = styled(Flex)`
   ${({ theme, flexDirection }) => {
     if (flexDirection === 'row') {
-      return `${Button} + ${Button} {
-        margin-left: ${theme.space.small};
+      return `${Button}:not(:last-child) {
+        margin-right: ${theme.space.small}
       }`;
     } else {
       return `${Button} + ${Button} {


### PR DESCRIPTION
Changed the margin for buttons within a button group. Although this is not an equivalent rule it shouldn't cause issues as the change is contained to the group itself. Comments/ideas welcome.

**Before**
<img width="725" alt="Screenshot 2020-02-09 at 16 46 35" src="https://user-images.githubusercontent.com/9862670/74107114-6c647080-4b75-11ea-9fc8-8057b43fb422.png">

**After**
<img width="746" alt="Screenshot 2020-02-09 at 16 44 01" src="https://user-images.githubusercontent.com/9862670/74107115-71c1bb00-4b75-11ea-8d77-ada5504fbf6e.png">
