### PR TITLE
Fix to allow building on now.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "engines": {
-    "node": "12.13.1"
+    "node": "12.x"
   },
   "files": [
     "src",


### PR DESCRIPTION
Because of changes to `now` we can not pass an 

```
"engine": {
    "node": "12.13.1"
}
```

But have to pass a `"12.x"` engine